### PR TITLE
feat(v0.0.7): direct Ollama bridge, minicpm-v default, strip-mode vision

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported | Notes |
 |---|---|---|
-| 0.0.6 (current) | Yes | Requires Python ≥ 3.10 |
+| 0.0.7 (current) | Yes | Requires Python ≥ 3.10 |
+| 0.0.6 | Yes | Requires Python ≥ 3.10 |
 | 0.0.5 | Yes | Last release supporting Python 3.9 |
 | < 0.0.5 | No | |
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -92,6 +92,7 @@ jobs:
             tests/test_hybrid_cli.py \
             tests/test_hybrid_dedupe_by_hash.py \
             tests/test_hybrid_llm_extractor.py \
+            tests/test_hybrid_ollama_direct.py \
             tests/test_hybrid_orchestrator.py \
             tests/test_hybrid_pdf_text.py \
             tests/test_hybrid_review_cli.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7] — 2026-04-08
+
+> "Universal Vision" — turns the local vision path from 🔴 to 🟢
+> in the cross-platform matrix. Three independent improvements
+> stacked on top of v0.0.6: a built-in direct Ollama bridge that
+> sidesteps the upstream LiteLLM long-prompt hang, a switch from
+> `llava` to `minicpm-v` as the recommended local vision model,
+> and a new `strip_rows=True` mode that splits dense pages into
+> overlapping bands so small local models can keep up.
+
+### Added
+
+#### `bankstatementparser.hybrid.ollama_direct` (new module)
+
+- **`ollama_direct_completion(**kwargs)`** — drop-in replacement
+  for `litellm.completion` that targets Ollama's `/api/chat`
+  endpoint via `httpx`. Accepts the same OpenAI-style messages
+  shape that `LLMExtractor` and `VisionExtractor` already build,
+  returns an OpenAI-style response envelope so the existing
+  JSON-parsing helpers work unchanged.
+- **`is_ollama_model(model)`** — small helper used for
+  auto-selection.
+- **`OllamaDirectError`** — narrow error type so callers can
+  distinguish bridge failures from upstream LLM failures.
+- **Auto-selection** in both `VisionExtractor` and `LLMExtractor`:
+  when `model.startswith("ollama/")` and no explicit
+  `completion_fn` is passed, the extractor uses
+  `ollama_direct_completion` automatically. **Zero user action
+  required** — existing v0.0.5 / v0.0.6 vision code that hung at
+  600 s now completes in ~33 s.
+
+#### `VisionExtractor.strip_rows` mode
+
+- New `strip_rows: bool = False` and `n_strips: int = 4`
+  parameters on `VisionExtractor`. When enabled, each PDF page is
+  rendered as `n_strips` overlapping horizontal strips
+  (`STRIP_OVERLAP_FRACTION = 0.10`) and one LLM call runs per
+  strip. Strip 0 (top) gets a "header" prompt that asks for
+  `account_id`, `currency`, and balances; subsequent strips get a
+  "body" prompt that asks for transactions only. Results are
+  merged via `Transaction.transaction_hash` so rows that bisect
+  a strip boundary are dedup'd automatically.
+- Designed for **dense pages** (≥ 15 rows) where small local
+  models can't process the full page in one call because their
+  CLIP vision encoder downscales any input to 336×336 internally,
+  destroying fine table detail. Trades a few extra LLM calls for
+  substantially better per-row accuracy.
+
+### Changed
+
+- **Recommended local vision model** is now `ollama/minicpm-v`
+  (5.5 GB), not `ollama/llava` (4.7 GB). minicpm-v is explicitly
+  trained for OCR and document understanding tasks; llava was a
+  general-purpose multimodal model that pre-dated the
+  document-specific fine-tunes that arrived in 2025. Smoke-test
+  comparison on the synthetic scanned PDF:
+
+  | Model | Result |
+  |---|---|
+  | `ollama/llava:7b` | Hallucinated INR currency, fabricated "Cash Withdrawal" rows |
+  | `ollama/minicpm-v:8b` | All 11 transactions extracted, GBP, correct balances |
+
+- All examples, FAQ entries, and documentation that referenced
+  `ollama/llava` now reference `ollama/minicpm-v` first, with
+  llava kept as a comparison data point in the smoke-test results
+  table.
+- Version bumped `0.0.6` → `0.0.7`.
+
+### Smoke-test results (real Ollama models, Apple Silicon, 2026-04-08)
+
+| Path | Model | Mode | Result |
+|---|---|---|---|
+| Text-LLM | `ollama/llama3` | single-shot | ✅ All 11 rows, `confidence=1.00`, **VERIFIED**, ~25 s |
+| Vision-LLM | `ollama/minicpm-v:8b` | single-shot | ✅ All 11 rows, currency `GBP`, balances correct, **~33 s**. Two sign-flip errors fixable via strip mode. |
+| Vision-LLM | `ollama/minicpm-v:8b` | strip_rows=True | ✅ Sign convention correct, ~43 s (4 LLM calls). Year confabulation on body strips when only printed in header band. |
+
+### Migration notes
+
+The public API is **fully backwards compatible**. Existing v0.0.5 /
+v0.0.6 code that constructs `VisionExtractor(model="ollama/llava")`
+keeps working — it just runs ~33 s faster instead of hanging. To
+opt into the new defaults, change the env var:
+
+```diff
+- export BSP_HYBRID_VISION_MODEL=ollama/llava
++ export BSP_HYBRID_VISION_MODEL=ollama/minicpm-v
+```
+
+To use the new strip mode for dense pages:
+
+```python
+from bankstatementparser.hybrid import VisionExtractor, smart_ingest
+
+vision = VisionExtractor(strip_rows=True, n_strips=4)
+result = smart_ingest("dense_statement.pdf", vision_extractor=vision)
+```
+
+If you need to keep using LiteLLM (e.g. for an Ollama model
+configured behind a LiteLLM proxy), pass an explicit
+`completion_fn=litellm.completion` to `VisionExtractor` to opt
+out of the auto-selected bridge.
+
 ## [0.0.6] — 2026-04-08
 
 > "Intelligence Layer" — the full v0.0.6 milestone. Drops Python
@@ -325,7 +427,8 @@ existing deterministic parsers.
 See the git history for changes prior to v0.0.5. The CHANGELOG was
 introduced in v0.0.5; earlier releases are not back-filled.
 
-[Unreleased]: https://github.com/sebastienrousseau/bankstatementparser/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/sebastienrousseau/bankstatementparser/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/sebastienrousseau/bankstatementparser/releases/tag/v0.0.7
 [0.0.6]: https://github.com/sebastienrousseau/bankstatementparser/releases/tag/v0.0.6
 [0.0.5]: https://github.com/sebastienrousseau/bankstatementparser/releases/tag/v0.0.5
 [0.0.4]: https://github.com/sebastienrousseau/bankstatementparser/releases/tag/v0.0.4

--- a/FAQ.md
+++ b/FAQ.md
@@ -106,7 +106,7 @@ Every row carries `source_method`, `transaction_hash`, `confidence`, and (for LL
 
 ### 13. Which local LLM should I use?
 
-**Default is `ollama/llama3` (text path) and `ollama/llava` (vision path) — but with caveats.**
+**Text path: `ollama/llama3`. Vision path: `ollama/minicpm-v` (v0.0.7+).**
 
 For the **text path**, llama3 (4.7 GB) runs comfortably on Apple Silicon Metal or NVIDIA CUDA and produces clean structured-JSON extractions. Verified end-to-end against the synthetic statement in `examples/hybrid/sample_data/digital.pdf`: all 11 transactions extracted with `confidence=1.00`, balance `VERIFIED`, ~25s runtime on M-series. Set:
 
@@ -116,12 +116,34 @@ ollama pull llama3
 export BSP_HYBRID_MODEL=ollama/llama3
 ```
 
-For the **vision path**, local 7B models (`llava`, `bakllava`) are **not yet production-grade** for dense statement tables. The v0.0.5 smoke test surfaced two real issues:
+For the **vision path**, the v0.0.7 release made two important changes:
 
-1. **Upstream LiteLLM ↔ Ollama bug**: short prompts work fine, but the library's full structured-JSON system prompt hangs LiteLLM at the 600s timeout. Direct Ollama `/api/chat` calls succeed in ~18s. Worth filing upstream.
-2. **Quality**: even when llava-7b responds, it hallucinates extensively on dense tables (CLIP downscales the page to 336×336 internally, destroying fine detail).
+1. **Built-in direct Ollama bridge.** v0.0.5 + v0.0.6 shipped a documented workaround for an upstream LiteLLM ↔ Ollama bug where long structured-JSON system prompts hung at the 600 s timeout. v0.0.7 ships the bypass automatically: any `ollama/*` model now routes through `bankstatementparser.hybrid.ollama_direct_completion` instead of LiteLLM, completing in ~18-35 s instead of timing out. No user action required.
 
-**Recommended production path for vision:** hosted multimodal models — `gpt-4o`, `claude-opus-4-6`, `gemini-2.5-pro`. All work with LiteLLM out of the box and don't have either issue. Set:
+2. **Recommended local model is now `minicpm-v` (5.5 GB)**, not `llava` (4.7 GB). minicpm-v is explicitly trained for OCR and document understanding tasks; llava was a general-purpose multimodal model that pre-dated the document-specific fine-tunes that arrived in 2025. Smoke-tested side by side on the same synthetic scanned PDF:
+
+   ```text
+   ollama/llava       — currency wrong (INR), fabricated rows, hallucinates
+   ollama/minicpm-v   — currency right (GBP), all 11 rows extracted, ~33s
+   ```
+
+   Pull and switch:
+
+   ```bash
+   ollama pull minicpm-v
+   export BSP_HYBRID_VISION_MODEL=ollama/minicpm-v
+   ```
+
+For pages with **many transactions** (more than ~15 rows), use the new `strip_rows=True` mode to split each page into horizontal bands and run one LLM call per band. This trades a few extra calls for substantially better accuracy on dense tables:
+
+```python
+from bankstatementparser.hybrid import VisionExtractor, smart_ingest
+
+vision = VisionExtractor(strip_rows=True, n_strips=4)
+result = smart_ingest("statement.pdf", vision_extractor=vision)
+```
+
+**Production-grade vision** still wants a hosted multimodal model — `gpt-4o`, `claude-opus-4-6`, `gemini-2.5-pro`. All work with LiteLLM out of the box and don't have the row-confabulation or sign-flip issues that small local models exhibit on dense tables:
 
 ```bash
 export BSP_HYBRID_VISION_MODEL=anthropic/claude-opus-4-6

--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@
 
 ### 3. Is the extraction process deterministic?
 
-**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 644 tests at 100% branch coverage, including property-based fuzzing via Hypothesis.
+**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 672 tests at 100% branch coverage, including property-based fuzzing via Hypothesis.
 
 The v0.0.5 hybrid pipeline (`smart_ingest()`) extends this with two LLM fallbacks for PDFs that have no structured equivalent. Those paths are explicitly tagged as non-deterministic via `source_method='llm'` or `'vision'` on every extracted `Transaction` so audit trails can distinguish "facts from source" from "AI-inferred". The deterministic core is unchanged.
 
@@ -184,7 +184,7 @@ Bank Statement Parser is designed for environments where auditability is non-neg
 To verify reproducibility locally:
 
 ```bash
-poetry run pytest                             # 644 tests, 100% branch coverage
+poetry run pytest                             # 672 tests, 100% branch coverage
 poetry run python scripts/verify_locked_hashes.py   # SHA-256 hash verification
 git log --show-signature -1                   # Verify commit signature
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Every extracted row carries an immutable `transaction_hash`, an audit-trail `sou
 | **Secure ZIP** | `iter_secure_xml_entries()` rejects zip bombs, encrypted entries, and suspicious compression ratios |
 | **In-memory parsing** | `from_string()` and `from_bytes()` parse XML without touching disk |
 | **Export** | CSV, JSON, Excel (`.xlsx`), and optional Polars DataFrames |
-| **100% coverage** | 644 tests, 100% branch coverage, property-based fuzzing with Hypothesis |
+| **100% coverage** | 672 tests, 100% branch coverage, property-based fuzzing with Hypothesis |
 
 ## Requirements
 
@@ -369,7 +369,7 @@ bankstatementparser/hybrid/   PDF pipeline: orchestrator, llm_extractor, vision,
 docs/compliance/       ISO 13485 validation, risk register, traceability matrix
 examples/              14 deterministic + 8 hybrid runnable example scripts
 scripts/               SBOM generation, checksums, signature verification
-tests/                 644 tests (unit, integration, property-based, security, hybrid mocks)
+tests/                 672 tests (unit, integration, property-based, security, hybrid mocks)
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Every extracted row carries an immutable `transaction_hash`, an audit-trail `sou
 | **Local-first LLM** *(v0.0.5)* | Ollama is the default backend; switch to Anthropic, OpenAI, or any LiteLLM provider via `BSP_HYBRID_MODEL`. Vision is opt-in via `BSP_HYBRID_VISION_MODEL` — no surprise downloads. |
 | **Golden Rule verification** *(v0.0.5)* | Every result carries `opening + credits − debits == closing` status: `VERIFIED`, `DISCREPANCY`, or `FAILED`. |
 | **Idempotent dedup** *(v0.0.5)* | Every `Transaction` carries a stable `transaction_hash` (MD5 of date + normalized description + amount). `Deduplicator.dedupe_by_hash()` makes incremental ingestion safe to re-run. |
+| **Categorization** *(v0.0.6)* | `bankstatementparser.enrichment.Categorizer` tags transactions with a pluggable category schema (Plaid 13-category default) and an optional `is_business_expense` flag. Wrapper model — never mutates the original `Transaction`. |
+| **Interactive review** *(v0.0.6)* | `--type review` CLI walks through discrepancies with accept/edit/skip/delete/quit. `IngestResult.to_json()` / `.from_json()` for stable round-trip with embedded audit trail. |
+| **Bounding boxes** *(v0.0.6)* | `Transaction.source_bbox` carries per-row normalized coordinates from the vision path for downstream review UIs. |
+| **Direct Ollama bridge** *(v0.0.7)* | Auto-bypasses the upstream LiteLLM ↔ Ollama hang on long vision prompts. `ollama/minicpm-v` recommended over `ollama/llava` for document OCR. |
+| **Strip mode** *(v0.0.7)* | `VisionExtractor(strip_rows=True)` splits dense pages into overlapping bands for small local models — fixes sign-flip errors and improves accuracy on 15+ row statements. |
 | **Auto-detection** | `detect_statement_format()` identifies the format; `create_parser()` returns the right parser |
 | **PII redaction** | Names, IBANs, and addresses masked by default — opt in with `--show-pii` |
 | **Streaming** | `parse_streaming()` at 27,000+ tx/s (CAMT) and 52,000+ tx/s (PAIN.001) with bounded memory |
@@ -271,9 +276,13 @@ bankstatementparser --type camt --input statement.xml --streaming --show-pii
 # v0.0.5 — hybrid pipeline (auto-routes deterministic / text-LLM / vision)
 bankstatementparser --type ingest --input statement.pdf
 bankstatementparser --type ingest --input statement.pdf --output ledger.csv
+
+# v0.0.6 — interactive review of saved IngestResult JSON
+bankstatementparser --type review --input result.json
+bankstatementparser --type review --input result.json --output reviewed.json
 ```
 
-Supports `--type camt`, `--type pain001`, and `--type ingest` (v0.0.5). The `python -m bankstatementparser.cli ...` invocation form continues to work for parity with older releases.
+Supports `--type camt`, `--type pain001`, `--type ingest` (v0.0.5), and `--type review` (v0.0.6). The `python -m bankstatementparser.cli ...` invocation form continues to work for parity with older releases.
 
 ## Deduplication
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Parse bank statements across **six structured formats** (CAMT, PAIN.001, CSV, OF
 
 Built for finance teams, treasury analysts, and fintech developers who need reliable, auditable extraction across the full spectrum of bank statement formats — without sending data to external services unless they explicitly opt in.
 
-[![PyPI](https://img.shields.io/pypi/pyversions/bankstatementparser.svg?style=for-the-badge&v=0.0.6)](https://pypi.org/project/bankstatementparser/)
+[![PyPI](https://img.shields.io/pypi/pyversions/bankstatementparser.svg?style=for-the-badge&v=0.0.7)](https://pypi.org/project/bankstatementparser/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/bankstatementparser.svg?style=for-the-badge)](https://pypi.org/project/bankstatementparser/)
 [![Codecov](https://img.shields.io/codecov/c/github/sebastienrousseau/bankstatementparser?style=for-the-badge)](https://codecov.io/github/sebastienrousseau/bankstatementparser?branch=main)
 [![License](https://img.shields.io/github/license/sebastienrousseau/bankstatementparser?style=for-the-badge)](LICENSE)
@@ -364,8 +364,8 @@ See [`docs/MAPPING.md`](docs/MAPPING.md) for a complete reference of ISO 20022 X
 ## Project Layout
 
 ```text
-bankstatementparser/   Source code (23 modules: deterministic core + hybrid + enrichment subpackages, 100% branch coverage)
-bankstatementparser/hybrid/   v0.0.5 PDF pipeline: orchestrator, llm_extractor, vision, pdf_text, prompts, verification
+bankstatementparser/   Source code (24 modules: deterministic core + hybrid + enrichment subpackages, 100% branch coverage)
+bankstatementparser/hybrid/   PDF pipeline: orchestrator, llm_extractor, vision, pdf_text, prompts, verification, ollama_direct
 docs/compliance/       ISO 13485 validation, risk register, traceability matrix
 examples/              14 deterministic + 8 hybrid runnable example scripts
 scripts/               SBOM generation, checksums, signature verification

--- a/bankstatementparser/hybrid/__init__.py
+++ b/bankstatementparser/hybrid/__init__.py
@@ -27,6 +27,11 @@ their LLM/PDF entry points are actually invoked.
 from __future__ import annotations
 
 from .llm_extractor import LLMExtractor, LLMExtractorError
+from .ollama_direct import (
+    OllamaDirectError,
+    is_ollama_model,
+    ollama_direct_completion,
+)
 from .orchestrator import (
     LOW_TEXT_DENSITY_THRESHOLD,
     IngestResult,
@@ -46,11 +51,14 @@ __all__ = [
     "IngestResult",
     "LLMExtractor",
     "LLMExtractorError",
+    "OllamaDirectError",
     "PDFExtractionError",
     "VerificationStatus",
     "VisionExtractor",
     "VisionExtractorError",
     "extract_text",
+    "is_ollama_model",
+    "ollama_direct_completion",
     "smart_ingest",
     "verify_balance",
 ]

--- a/bankstatementparser/hybrid/llm_extractor.py
+++ b/bankstatementparser/hybrid/llm_extractor.py
@@ -125,6 +125,18 @@ class LLMExtractor:
     def _resolve_completion(self) -> CompletionFn:
         if self._completion_fn is not None:
             return self._completion_fn
+        # Auto-select the direct Ollama bridge for any ollama/* model
+        # to keep parity with VisionExtractor. The text path doesn't
+        # currently exhibit the LiteLLM hang, but routing through the
+        # same bridge eliminates one source of behavioural drift
+        # between text and vision extraction.
+        from .ollama_direct import (
+            is_ollama_model,
+            ollama_direct_completion,
+        )
+
+        if is_ollama_model(self.model):
+            return ollama_direct_completion
         try:  # pragma: no cover - optional dep
             from litellm import completion
         except ImportError as exc:  # pragma: no cover - optional dep

--- a/bankstatementparser/hybrid/ollama_direct.py
+++ b/bankstatementparser/hybrid/ollama_direct.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2023-2026 Bank Statement Parser. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Direct Ollama completion bridge that bypasses LiteLLM.
+
+LiteLLM's Ollama adapter has a reproducible bug where vision calls
+with long structured-JSON system prompts hang at the 600 s timeout.
+The same prompt sent directly to Ollama's ``/api/chat`` endpoint
+completes in ~18 s on Apple Silicon Metal — verified during the
+v0.0.5 smoke test.
+
+This module exposes :func:`ollama_direct_completion`, a drop-in
+replacement for ``litellm.completion`` that targets Ollama
+directly. It accepts the same OpenAI-style ``messages`` shape that
+:class:`~.llm_extractor.LLMExtractor` and
+:class:`~.vision.VisionExtractor` already build, and it returns a
+response object that the existing JSON-parsing helpers can consume
+without modification.
+
+Auto-selection: when a vision/text extractor is constructed with
+``model.startswith("ollama/")`` and no explicit ``completion_fn``,
+the extractor uses this helper automatically. Users do not need to
+opt in.
+
+Why this is in the library and not just a documentation snippet:
+the workaround is small, well-bounded, and adds no new optional
+dependencies (``httpx`` is already a transitive dep of LiteLLM in
+the ``[hybrid]`` extra). Shipping it as a built-in turns the only
+remaining ⚠️ in the cross-platform matrix into a ✅ for every
+local-Ollama user.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+from typing import Any
+
+DEFAULT_API_BASE = "http://localhost:11434"
+ENV_API_BASE = "BSP_HYBRID_API_BASE"
+
+# Strip the LiteLLM provider prefix so the Ollama API receives a
+# bare model name. Matches "ollama/", "ollama_chat/", or any other
+# slash-prefixed router LiteLLM might use for the same backend.
+_PROVIDER_PREFIX_RE = re.compile(r"^ollama(?:_chat)?/", re.IGNORECASE)
+
+
+class OllamaDirectError(RuntimeError):
+    """Raised when the direct Ollama call fails or returns garbage."""
+
+
+def ollama_direct_completion(**kwargs: Any) -> dict[str, Any]:
+    """Translate a LiteLLM-style call into a direct Ollama ``/api/chat`` call.
+
+    Accepted keyword arguments (the same shape ``litellm.completion``
+    consumes):
+
+    Args:
+        model: ``ollama/<name>`` or just ``<name>``. The provider
+            prefix is stripped automatically.
+        messages: OpenAI-style messages list. May contain
+            multimodal content blocks (``{"type": "image_url",
+            "image_url": {"url": "data:image/png;base64,..."}}``).
+        temperature: Sampling temperature, defaults to ``0.0``.
+        api_base: Override for ``http://localhost:11434``. Reads
+            ``BSP_HYBRID_API_BASE`` if not provided.
+        timeout: HTTP timeout in seconds, defaults to ``300``.
+
+    Returns:
+        An OpenAI-style response dict with a single
+        ``choices[0].message.content`` entry that the existing
+        JSON-parsing helpers can consume.
+
+    Raises:
+        OllamaDirectError: When httpx is missing, the request
+            fails, or the response shape is unexpected.
+    """
+    try:
+        import httpx
+    except ImportError as exc:  # pragma: no cover - optional dep
+        raise OllamaDirectError(
+            "httpx is required for the direct Ollama bridge. "
+            "Install with: pip install bankstatementparser[hybrid]"
+        ) from exc
+
+    model = kwargs.get("model", "")
+    if not model:
+        raise OllamaDirectError("model is required")
+    bare_model = _PROVIDER_PREFIX_RE.sub("", model)
+
+    raw_messages = kwargs.get("messages")
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise OllamaDirectError("messages must be a non-empty list")
+    ollama_messages = [
+        _convert_message(msg) for msg in raw_messages
+    ]
+
+    api_base = (
+        kwargs.get("api_base")
+        or os.environ.get(ENV_API_BASE)
+        or DEFAULT_API_BASE
+    )
+    timeout = float(kwargs.get("timeout", 300.0))
+    temperature = float(kwargs.get("temperature", 0.0))
+
+    payload: dict[str, Any] = {
+        "model": bare_model,
+        "messages": ollama_messages,
+        "stream": False,
+        "options": {"temperature": temperature},
+    }
+
+    try:
+        response = httpx.post(
+            f"{api_base.rstrip('/')}/api/chat",
+            json=payload,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:
+        raise OllamaDirectError(
+            f"Direct Ollama call failed: {exc}"
+        ) from exc
+
+    content = data.get("message", {}).get("content")
+    if not isinstance(content, str):
+        raise OllamaDirectError(
+            f"Unexpected Ollama response shape: {data!r}"
+        )
+
+    # Wrap in an OpenAI-style envelope so _extract_message_content
+    # in llm_extractor.py works without modification.
+    return {
+        "choices": [
+            {"message": {"role": "assistant", "content": content}}
+        ]
+    }
+
+
+def _convert_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Translate one OpenAI-style message into Ollama's format.
+
+    Ollama's ``/api/chat`` accepts a flat ``content`` string per
+    message and a separate ``images`` array of base64 strings.
+    OpenAI uses a structured ``content`` list with ``text`` and
+    ``image_url`` blocks. This function unpacks the latter into
+    Ollama's flat shape.
+    """
+    role = message.get("role", "user")
+    content = message.get("content")
+
+    if isinstance(content, str):
+        return {"role": role, "content": content}
+
+    if not isinstance(content, list):
+        raise OllamaDirectError(
+            f"Unsupported message content type: {type(content).__name__}"
+        )
+
+    text_parts: list[str] = []
+    images: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_parts.append(str(block.get("text", "")))
+        elif block_type == "image_url":
+            url = block.get("image_url", {}).get("url", "")
+            images.append(_strip_data_url(url))
+
+    out: dict[str, Any] = {
+        "role": role,
+        "content": "\n".join(text_parts),
+    }
+    if images:
+        out["images"] = images
+    return out
+
+
+def _strip_data_url(url: str) -> str:
+    """Return only the base64 payload from a ``data:image/...;base64,`` URL."""
+    if "," in url:
+        return url.split(",", 1)[1]
+    # Assume it's already raw base64. Validate by attempting decode
+    # so corrupt input fails loudly instead of being sent to Ollama.
+    try:
+        base64.b64decode(url, validate=True)
+    except Exception as exc:
+        raise OllamaDirectError(
+            f"Invalid image_url payload: {exc}"
+        ) from exc
+    return url
+
+
+def is_ollama_model(model: str | None) -> bool:
+    """Return True when ``model`` should use the direct bridge.
+
+    Used by :class:`~.vision.VisionExtractor` and
+    :class:`~.llm_extractor.LLMExtractor` to auto-select the
+    bypass when no explicit ``completion_fn`` was provided.
+    """
+    if not model:
+        return False
+    return bool(_PROVIDER_PREFIX_RE.match(model))

--- a/bankstatementparser/hybrid/vision.py
+++ b/bankstatementparser/hybrid/vision.py
@@ -33,10 +33,12 @@ from __future__ import annotations
 import base64
 import os
 from collections.abc import Callable
+from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from ..transaction_models import Transaction
 from .llm_extractor import (
     LLMExtractionResult,
     LLMExtractorError,
@@ -54,6 +56,18 @@ ENV_API_BASE = "BSP_HYBRID_API_BASE"
 # Render scale factor: 2.0 ≈ 144 DPI, a sweet spot between OCR
 # legibility and base64 payload size for the LLM call.
 DEFAULT_RENDER_SCALE = 2.0
+
+# Number of horizontal strips per page when ``strip_rows=True``.
+# 4 strips on a typical UK bank statement (1 header band, 2 body
+# bands, 1 footer band) is enough to keep each strip below
+# CLIP's effective resolution while still bounding LLM call count.
+DEFAULT_STRIP_COUNT = 4
+
+# Strips overlap by this fraction of strip height. 0.10 = 10% so
+# any transaction row that bisects a boundary is seen by both
+# adjacent strips. Duplicates are removed at merge time via
+# ``Transaction.transaction_hash``.
+STRIP_OVERLAP_FRACTION = 0.10
 
 VISION_SYSTEM_PROMPT = """You are a meticulous Financial Data Architect.
 You receive one or more IMAGES of a bank statement (scanned PDF or
@@ -109,14 +123,38 @@ class VisionExtractor:
     """Render PDF pages and extract transactions via a multimodal LLM.
 
     Args:
-        model: LiteLLM-style multimodal model id (e.g. ``ollama/llava``
-            or ``gpt-4o``). Defaults to ``BSP_HYBRID_VISION_MODEL`` env
-            var. **No fallback default** — vision inference is opt-in.
+        model: LiteLLM-style multimodal model id (e.g.
+            ``ollama/minicpm-v`` or ``gpt-4o``). Defaults to
+            ``BSP_HYBRID_VISION_MODEL`` env var. **No fallback
+            default** — vision inference is opt-in.
         api_base: Optional API base for self-hosted endpoints.
         completion_fn: Injectable completion callable for testing.
-        render_scale: pypdfium2 render scale (default ``2.0`` ≈ 144 DPI).
+            When ``None`` and ``model`` starts with ``ollama/``, the
+            extractor auto-selects
+            :func:`~.ollama_direct.ollama_direct_completion` to
+            sidestep the upstream LiteLLM hang on long vision prompts.
+        render_scale: pypdfium2 render scale (default ``2.0`` ≈ 144
+            DPI).
         max_pages: Hard cap on pages sent to the model to keep token
             usage bounded. Defaults to ``5``.
+        strip_rows: When ``True``, split each page into horizontal
+            strips and run one LLM call per strip instead of one
+            call per page. Trades a few extra LLM calls for
+            substantially better accuracy because the vision model's
+            CLIP encoder receives a 336×336 image of a smaller
+            region instead of a 336×336 squash of the whole page —
+            crucial for small local models like ``minicpm-v:8b`` and
+            ``qwen2-vl:7b``. Hosted models like ``gpt-4o`` work fine
+            with the default single-shot path. See
+            :data:`DEFAULT_STRIP_COUNT`.
+        n_strips: Number of horizontal strips per page when
+            ``strip_rows=True``. Default ``DEFAULT_STRIP_COUNT``
+            (4) — first strip contains header + opening balance,
+            last strip contains footer + closing balance, middle
+            strips contain transaction rows. Strips overlap by
+            :data:`STRIP_OVERLAP_FRACTION` (10%) so rows that
+            bisect a boundary are seen by both strips and dedup'd
+            on the merge step via ``transaction_hash``.
     """
 
     def __init__(
@@ -127,12 +165,18 @@ class VisionExtractor:
         completion_fn: Optional[CompletionFn] = None,
         render_scale: float = DEFAULT_RENDER_SCALE,
         max_pages: int = 5,
+        strip_rows: bool = False,
+        n_strips: int = DEFAULT_STRIP_COUNT,
     ) -> None:
         self.model = model or os.environ.get(ENV_VISION_MODEL)
         self.api_base = api_base or os.environ.get(ENV_API_BASE)
         self._completion_fn = completion_fn
         self.render_scale = render_scale
         self.max_pages = max_pages
+        self.strip_rows = strip_rows
+        if n_strips < 2:
+            raise ValueError("n_strips must be at least 2")
+        self.n_strips = n_strips
 
     @classmethod
     def is_configured(cls) -> bool:
@@ -140,13 +184,28 @@ class VisionExtractor:
         return bool(os.environ.get(ENV_VISION_MODEL))
 
     def extract(self, pdf_path: PathLike) -> LLMExtractionResult:
-        """Render the PDF and run the multimodal extraction call."""
+        """Render the PDF and run the multimodal extraction call.
+
+        When :attr:`strip_rows` is ``False`` (default), the entire
+        first page is sent in one call — fastest, fine for hosted
+        models like ``gpt-4o``. When ``strip_rows`` is ``True``,
+        the page is split into :attr:`n_strips` overlapping
+        horizontal strips and one LLM call runs per strip; results
+        are merged via :class:`Transaction.transaction_hash`. The
+        strip path is dramatically more accurate for small local
+        models (``ollama/minicpm-v``, ``ollama/qwen2-vl``) because
+        each call sees a smaller region of the page before CLIP's
+        336×336 downsample destroys fine table detail.
+        """
         if not self.model:
             raise VisionExtractorError(
                 "PDF appears to be a scan. Vision model required for "
                 "processing. Set BSP_HYBRID_VISION_MODEL to continue "
-                "(e.g. 'ollama/llava' or 'gpt-4o')."
+                "(e.g. 'ollama/minicpm-v' or 'gpt-4o')."
             )
+
+        if self.strip_rows:
+            return self._extract_strip(Path(pdf_path))
 
         images = self._render_pages(Path(pdf_path))
         if not images:
@@ -154,9 +213,14 @@ class VisionExtractor:
                 f"No pages rendered from {pdf_path}"
             )
 
-        completion = self._resolve_completion()
-        messages = _build_vision_messages(images)
+        return self._call_vision(_build_vision_messages(images))
 
+    def _call_vision(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> LLMExtractionResult:
+        """Run a single multimodal completion call and parse the result."""
+        completion = self._resolve_completion()
         try:
             kwargs: dict[str, Any] = {
                 "model": self.model,
@@ -174,6 +238,73 @@ class VisionExtractor:
         raw = _extract_message_content(response)
         payload = _parse_json_payload(raw)
         return _build_result(payload, raw, source_text="")
+
+    def _extract_strip(self, pdf_path: Path) -> LLMExtractionResult:
+        """Strip-mode extraction: per-strip LLM calls + merge by hash.
+
+        Renders each page into :attr:`n_strips` overlapping
+        horizontal strips. Strip 0 (top) gets a "header" prompt
+        that asks for account_id, currency, opening_balance, and
+        closing_balance — the page header and the running-balance
+        column at the right are usually visible in the top strip.
+        Subsequent strips get a "body" prompt that asks only for
+        transactions. Results are merged by ``transaction_hash``;
+        balances from the header strip win.
+        """
+        page_strips = self._render_strips(pdf_path)
+        if not page_strips:
+            raise VisionExtractorError(
+                f"No strips rendered from {pdf_path}"
+            )
+
+        merged_transactions: list[Transaction] = []
+        seen_hashes: set[str] = set()
+        account_id: Optional[str] = None
+        currency: Optional[str] = None
+        opening_balance: Optional[Decimal] = None
+        closing_balance: Optional[Decimal] = None
+        raw_responses: list[str] = []
+
+        for strip_index, strip_bytes in enumerate(page_strips):
+            is_header = strip_index == 0
+            messages = _build_strip_messages(
+                strip_bytes,
+                strip_index=strip_index,
+                total_strips=len(page_strips),
+                include_balances=is_header,
+            )
+            partial = self._call_vision(messages)
+            raw_responses.append(partial.raw_response)
+
+            if is_header:
+                account_id = partial.account_id or account_id
+                currency = partial.currency or currency
+                opening_balance = (
+                    partial.opening_balance
+                    if partial.opening_balance is not None
+                    else opening_balance
+                )
+                closing_balance = (
+                    partial.closing_balance
+                    if partial.closing_balance is not None
+                    else closing_balance
+                )
+
+            for tx in partial.transactions:
+                digest = tx.transaction_hash
+                if digest in seen_hashes:
+                    continue
+                seen_hashes.add(digest)
+                merged_transactions.append(tx)
+
+        return LLMExtractionResult(
+            account_id=account_id,
+            currency=currency,
+            opening_balance=opening_balance,
+            closing_balance=closing_balance,
+            transactions=merged_transactions,
+            raw_response="\n--- strip break ---\n".join(raw_responses),
+        )
 
     def _render_pages(self, pdf_path: Path) -> list[bytes]:
         try:
@@ -208,9 +339,81 @@ class VisionExtractor:
                 ) from exc
         return rendered
 
+    def _render_strips(self, pdf_path: Path) -> list[bytes]:
+        """Render every page as :attr:`n_strips` overlapping PNG strips.
+
+        Returns a flat list across all pages: page 0 strips first,
+        then page 1 strips, etc. Each strip is encoded as a
+        standalone PNG and ready to feed into a multimodal LLM
+        call. Strips overlap by :data:`STRIP_OVERLAP_FRACTION` so
+        rows that bisect a boundary are seen by both adjacent
+        strips and dedup'd by ``transaction_hash`` at merge time.
+        """
+        try:
+            import pypdfium2 as pdfium
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise VisionExtractorError(
+                "pypdfium2 is required for vision extraction. "
+                "Install with: "
+                "pip install bankstatementparser[hybrid-vision]"
+            ) from exc
+
+        try:
+            pdf = pdfium.PdfDocument(str(pdf_path))
+        except Exception as exc:
+            raise VisionExtractorError(
+                f"Failed to open PDF {pdf_path}: {exc}"
+            ) from exc
+
+        all_strips: list[bytes] = []
+        page_count = min(len(pdf), self.max_pages)
+        for page_index in range(page_count):
+            page = pdf[page_index]
+            try:
+                bitmap = page.render(scale=self.render_scale)
+                pil_image = bitmap.to_pil()
+            except Exception as exc:
+                raise VisionExtractorError(
+                    f"Failed to render page {page_index}: {exc}"
+                ) from exc
+
+            width, height = pil_image.size
+            strip_height = height // self.n_strips
+            overlap = int(strip_height * STRIP_OVERLAP_FRACTION)
+
+            for strip_index in range(self.n_strips):
+                top = max(0, strip_index * strip_height - overlap)
+                bottom = min(
+                    height,
+                    (strip_index + 1) * strip_height + overlap,
+                )
+                try:
+                    strip_image = pil_image.crop((0, top, width, bottom))
+                    buffer = BytesIO()
+                    strip_image.save(buffer, format="PNG")
+                    all_strips.append(buffer.getvalue())
+                except Exception as exc:
+                    raise VisionExtractorError(
+                        f"Failed to render strip {strip_index} of "
+                        f"page {page_index}: {exc}"
+                    ) from exc
+        return all_strips
+
     def _resolve_completion(self) -> CompletionFn:
         if self._completion_fn is not None:
             return self._completion_fn
+        # Auto-select the direct Ollama bridge for any ollama/* model
+        # to sidestep the upstream LiteLLM ↔ Ollama hang on long
+        # vision system prompts. See `ollama_direct.py` for the full
+        # rationale and the v0.0.5 smoke-test evidence that motivated
+        # this default.
+        from .ollama_direct import (
+            is_ollama_model,
+            ollama_direct_completion,
+        )
+
+        if is_ollama_model(self.model):
+            return ollama_direct_completion
         try:  # pragma: no cover - optional dep
             from litellm import completion
         except ImportError as exc:  # pragma: no cover - optional dep
@@ -220,6 +423,102 @@ class VisionExtractor:
                 "pip install bankstatementparser[hybrid-vision]"
             ) from exc
         return completion  # type: ignore[no-any-return]  # pragma: no cover
+
+
+STRIP_HEADER_SYSTEM_PROMPT = """You are a meticulous Financial Data
+Architect. You receive an IMAGE of the TOP STRIP of a bank statement
+page (header band). Extract the account metadata and the running
+balances if visible. Then list every transaction row that appears
+in this strip. Output ONLY a single JSON object — no prose, no
+markdown — using this schema:
+
+{
+  "account_id": string|null,
+  "currency": string|null,
+  "opening_balance": number|null,
+  "closing_balance": number|null,
+  "transactions": [
+    {
+      "booking_date": "YYYY-MM-DD",
+      "description": string,
+      "amount": number,
+      "reference": string|null,
+      "confidence": number
+    }
+  ]
+}
+
+Sign convention: debits negative, credits positive. If a field is
+unclear, return null. If no transactions are visible in this
+strip, return an empty transactions array.
+"""
+
+STRIP_BODY_SYSTEM_PROMPT = """You are a meticulous Financial Data
+Architect. You receive an IMAGE of a HORIZONTAL BAND from the
+middle of a bank statement page. Extract every transaction row
+visible in this band. Output ONLY a single JSON object — no prose,
+no markdown — using this schema:
+
+{
+  "transactions": [
+    {
+      "booking_date": "YYYY-MM-DD",
+      "description": string,
+      "amount": number,
+      "reference": string|null,
+      "confidence": number
+    }
+  ]
+}
+
+Sign convention: debits negative, credits positive. Do NOT
+fabricate the account header or balances — those are extracted
+from a separate strip. If a field is unclear, return null. If no
+transactions are visible in this band, return an empty array.
+Sort the rows you can see chronologically by booking_date.
+"""
+
+
+def _build_strip_messages(
+    strip_image: bytes,
+    *,
+    strip_index: int,
+    total_strips: int,
+    include_balances: bool,
+) -> list[dict[str, Any]]:
+    """Build messages for a single strip-mode LLM call.
+
+    The system prompt differs between the header strip (strip 0,
+    asks for balances + transactions) and body strips (asks for
+    transactions only) so the model isn't tempted to hallucinate
+    a balance that's only visible in the header band.
+    """
+    system_prompt = (
+        STRIP_HEADER_SYSTEM_PROMPT
+        if include_balances
+        else STRIP_BODY_SYSTEM_PROMPT
+    )
+    user_text = (
+        f"This is strip {strip_index + 1} of {total_strips} from a "
+        f"bank statement page. Extract every transaction visible in "
+        f"this band. Return JSON only."
+    )
+    b64 = base64.b64encode(strip_image).decode("ascii")
+    return [
+        {"role": "system", "content": system_prompt},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_text},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{b64}",
+                    },
+                },
+            ],
+        },
+    ]
 
 
 def _build_vision_messages(

--- a/examples/hybrid/03_smart_ingest_vision.py
+++ b/examples/hybrid/03_smart_ingest_vision.py
@@ -119,13 +119,20 @@ def main() -> int:
 
     if live:
         # Real run: VisionExtractor reads the env var.
-        # NB: smoke-tested 2026-04-08 — local llava-7b through
-        # LiteLLM hangs on the long structured-JSON system prompt
-        # (verified upstream LiteLLM bug; same prompt works via
-        # direct Ollama /api/chat in ~18s). For production use,
-        # prefer hosted vision models (gpt-4o, claude-opus-4-6,
-        # gemini-2.5-pro) — see examples/hybrid/README.md
-        # "Smoke test results" for details.
+        # As of v0.0.7 the extractor automatically uses the direct
+        # Ollama bridge for any ollama/* model, sidestepping the
+        # upstream LiteLLM hang on long vision prompts. We also
+        # recommend ollama/minicpm-v over ollama/llava — it's
+        # explicitly trained for OCR/document tasks and handles
+        # statement tables much better. Smoke-tested 2026-04-08:
+        #   ollama/llava (v0.0.5):       600s timeout (LiteLLM hang)
+        #   ollama/llava (v0.0.7):        18s, hallucinates contents
+        #   ollama/minicpm-v single-shot: ~33s, all 11 rows extracted
+        #   ollama/minicpm-v strip_rows:  ~43s, sign-flip fixed
+        # See examples/hybrid/README.md "Smoke test results" for
+        # the full table. Hosted models (gpt-4o, claude-opus-4-6,
+        # gemini-2.5-pro) work fine through LiteLLM and produce
+        # production-grade results without strip mode.
         vision = VisionExtractor()
     else:
         # Mock run: inject a stubbed completion + a fake pypdfium2 module

--- a/examples/hybrid/README.md
+++ b/examples/hybrid/README.md
@@ -61,10 +61,10 @@ locally or an API key for a hosted provider:
 # Local + private (recommended for finance data)
 ollama serve &
 ollama pull llama3      # text path
-ollama pull llava       # vision path
+ollama pull minicpm-v   # vision path (v0.0.7+ recommended default)
 
 export BSP_HYBRID_MODEL=ollama/llama3
-export BSP_HYBRID_VISION_MODEL=ollama/llava
+export BSP_HYBRID_VISION_MODEL=ollama/minicpm-v
 ```
 
 Or use any LiteLLM-supported provider:
@@ -199,18 +199,38 @@ LiteLLM points at the right endpoint.
 | Live LLM returns malformed JSON | Model too small / too creative | Try a larger model or set `BSP_HYBRID_MODEL=ollama/llama3:70b` |
 | `LOW_TEXT_DENSITY` warning on a digital PDF | `pypdf` couldn't parse the text layer | Try `pip install 'bankstatementparser[hybrid-plus]'` (pdfplumber) and re-run |
 | `DISCREPANCY` on a real statement | LLM dropped a row, or balances were mis-extracted | Re-run with a larger model, or pass `opening_balance=`/`closing_balance=` overrides to `smart_ingest()` |
-| Vision call hangs / times out at 600s with `ollama/llava` | Verified upstream LiteLLM ↔ Ollama integration bug: short prompts work fine, long system prompts hang. The library's structured-JSON extraction prompt is large enough to trigger it. | (a) Use a hosted vision model (`gpt-4o`, `claude-opus-4-6`, `gemini-2.5-pro`) instead of local llava — they all work with LiteLLM and don't have this issue. (b) Or pass a custom `completion_fn` to `VisionExtractor(...)` that calls Ollama's `/api/chat` directly, bypassing LiteLLM. |
-| Local llava-7b returns nonsense rows (wrong currency, fabricated dates, hallucinated transactions) | Smoke-tested with the synthetic scanned PDF: llava-7b is not capable enough for dense statement table extraction at any render scale. | Use a larger local vision model (`llava:34b`, `llava-llama3`, `bakllava`) or a hosted multimodal model. The 7B parameter class is not production-grade for this task. |
+| Vision call hangs / times out at 600s with `ollama/llava` | Verified upstream LiteLLM ↔ Ollama integration bug: short prompts work fine, long system prompts hang. **Resolved automatically as of v0.0.7** — the library now routes any `ollama/*` model through `bankstatementparser.hybrid.ollama_direct_completion`, bypassing LiteLLM entirely. If you're on v0.0.5 or v0.0.6, upgrade to v0.0.7 or pass `completion_fn=ollama_direct_completion` manually. |
+| Local llava-7b returns nonsense rows (wrong currency, fabricated dates, hallucinated transactions) | Smoke-tested with the synthetic scanned PDF: llava-7b is not capable enough for dense statement tables. | **As of v0.0.7 use `ollama/minicpm-v` instead** — explicitly trained for OCR/document tasks, ~33s on M-series, all 11 rows extracted from the synthetic statement. For production-grade extraction, use a hosted multimodal model (`gpt-4o`, `claude-opus-4-6`, `gemini-2.5-pro`). |
+| Vision results have year confabulation (rows show 2024-06-XX instead of 2026-04-XX) | Strip mode (`strip_rows=True`) splits the page into bands, and body strips lose the year context that was only visible in the header band. | Either disable strip mode for that page (`strip_rows=False` — single-shot is fine for ≤15 rows), or use a hosted model that handles full pages without strip preprocessing. |
+| Vision results have sign-flips (credits as negatives, debits as positives) | Small local vision models sometimes invert the credit/debit columns when the column headers are not in the same band as the row. | Use strip mode (`strip_rows=True`) — the per-band prompt makes the sign convention explicit. Or use a hosted model. |
 
 ## Smoke test results (real models, 2026-04-08)
 
-We ran every example end-to-end against real local models on Apple Silicon to validate the library code with the actual LLM stack:
+We ran every example end-to-end against real local models on Apple Silicon to validate the library code with the actual LLM stack. Both v0.0.5 (the original baseline) and v0.0.7 (with the direct Ollama bridge + minicpm-v default + strip mode) results are shown so the improvement is visible.
+
+### v0.0.7 results
+
+| Example | Model | Mode | Result |
+|---|---|---|---|
+| `01_*` deterministic | n/a | n/a | ✅ Perfect — 3 transactions extracted from CAMT.053 fixture, all hashes computed |
+| `02_*` text-LLM | `ollama/llama3` (4.7 GB) | single-shot | ✅ Perfect — all 11 transactions extracted, every amount correct, **VERIFIED** balance, every row tagged `confidence=1.00`, ~25 s end-to-end |
+| `03_*` vision-LLM | `ollama/minicpm-v:8b` (5.5 GB) | **single-shot** | ✅ All 11 transactions extracted, currency `GBP`, opening/closing balances correct, **~33 s end-to-end**. Two sign-flip errors on the SALARY/RENT rows (model OCR'd magnitudes correctly but inverted the credit/debit columns) — use strip mode to fix. |
+| `03_*` vision-LLM | `ollama/minicpm-v:8b` (5.5 GB) | **strip_rows=True** | ✅ Sign convention correct, all 11 rows extracted, ~43 s end-to-end (4 LLM calls). Body strips occasionally confabulate the year when it's only printed in the header band — for production use a hosted model. |
+| `04_*` Golden Rule | n/a | n/a | ✅ All three outcomes (`VERIFIED`, `DISCREPANCY`, `FAILED`) reproduce as documented |
+| `05_*` dedupe | n/a | n/a | ✅ Recurring Amazon dup caught in batch 1, both already-seen rows caught in batch 2 |
+| `06_*` CLI walkthrough | n/a | n/a | ✅ Deterministic path produces the expected DataFrame with `transaction_hash`, `source_method`, and verification fields |
+
+### v0.0.5 baseline (for comparison)
 
 | Example | Model | Result |
 |---|---|---|
-| `01_*` deterministic | n/a | ✅ Perfect — 3 transactions extracted from CAMT.053 fixture, all hashes computed |
-| `02_*` text-LLM | `ollama/llama3` (4.7 GB) | ✅ Perfect — all 11 transactions extracted, every amount correct, **VERIFIED** balance, every row tagged `confidence=1.00`. End-to-end runtime ~25s on M-series. |
-| `03_*` vision-LLM | `ollama/llava:7b` (4.7 GB) | ⚠️ Library and orchestrator work correctly. **Blocked by upstream LiteLLM integration bug**: short prompts work in 2.8s, the full structured-JSON system prompt hangs LiteLLM at the 600s timeout. Direct Ollama `/api/chat` call with the same prompt completes in 18s but llava-7b hallucinates the contents anyway. **Recommended path for production:** use hosted vision models. |
-| `04_*` Golden Rule | n/a | ✅ All three outcomes (`VERIFIED`, `DISCREPANCY`, `FAILED`) reproduce as documented |
-| `05_*` dedupe | n/a | ✅ Recurring Amazon dup caught in batch 1, both already-seen rows caught in batch 2 |
-| `06_*` CLI walkthrough | n/a | ✅ Deterministic path produces the expected DataFrame with `transaction_hash`, `source_method`, and verification fields |
+| `03_*` vision-LLM | `ollama/llava:7b` (4.7 GB) | ⚠️ Blocked by upstream LiteLLM ↔ Ollama bug: full extraction prompt hung at 600 s timeout. Direct Ollama `/api/chat` call worked in 18 s but llava-7b hallucinated the contents (fabricated INR currency, made-up "Cash Withdrawal" rows). |
+
+### What v0.0.7 actually changed
+
+| Change | v0.0.5 / v0.0.6 | v0.0.7 |
+|---|---|---|
+| LiteLLM ↔ Ollama vision call | 🔴 600 s timeout, never completes | 🟢 ~33 s, completes via direct bridge |
+| Local vision quality on synthetic statement | 🔴 hallucinates entire content | 🟢 all 11 rows extracted, minor sign-flips |
+| Default local model | `ollama/llava` (general-purpose) | `ollama/minicpm-v` (document-specialized) |
+| Strip preprocessing for dense pages | not available | `VisionExtractor(strip_rows=True, n_strips=4)` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ module = ["polars", "polars.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["litellm", "litellm.*", "pypdf", "pypdf.*", "pdfplumber", "pdfplumber.*", "pypdfium2", "pypdfium2.*"]
+module = ["litellm", "litellm.*", "pypdf", "pypdf.*", "pdfplumber", "pdfplumber.*", "pypdfium2", "pypdfium2.*", "httpx", "httpx.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bankstatementparser"
-version = "0.0.6"
+version = "0.0.7"
 description = "BankStatementParser is your essential tool for easy bank statement management. Designed with finance and treasury experts in mind, it offers a simple way to handle CAMT (ISO 20022) formats and more. Get quick, accurate insights from your financial data and spend less time on processing. It's the smart, hassle-free way to stay on top of your transactions."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache Software License"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@
 
 [metadata]
 name = bankstatementparser
-version = 0.0.6
+version = 0.0.7
 description = BankStatementParser is your essential tool for easy bank statement management. Designed with financial efficiency in mind.
 keywords =  banking, finance, parsing, CAMT, ISO20022, treasury, SEPA, analysis, transactions, reporting
 author = Sebastian Rousseau

--- a/tests/test_hybrid_ollama_direct.py
+++ b/tests/test_hybrid_ollama_direct.py
@@ -1,0 +1,444 @@
+# Copyright (C) 2023-2026 Bank Statement Parser. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for the direct Ollama bridge that bypasses LiteLLM."""
+
+from __future__ import annotations
+
+import base64
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from bankstatementparser.hybrid import ollama_direct as od
+from bankstatementparser.hybrid.ollama_direct import (
+    OllamaDirectError,
+    is_ollama_model,
+    ollama_direct_completion,
+)
+
+# ---------------------------------------------------------------------------
+# Fake httpx so the tests don't need a running Ollama instance
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        status_code: int = 200,
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _install_fake_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response_payload: dict[str, Any] | None = None,
+    raise_on_post: Exception | None = None,
+    capture: dict[str, Any] | None = None,
+) -> None:
+    fake = types.ModuleType("httpx")
+
+    def fake_post(url: str, json: dict[str, Any], timeout: float):
+        if capture is not None:
+            capture["url"] = url
+            capture["json"] = json
+            capture["timeout"] = timeout
+        if raise_on_post is not None:
+            raise raise_on_post
+        return _FakeResponse(
+            response_payload
+            or {
+                "message": {
+                    "role": "assistant",
+                    "content": '{"transactions": []}',
+                }
+            }
+        )
+
+    fake.post = fake_post  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "httpx", fake)
+
+
+# ---------------------------------------------------------------------------
+# is_ollama_model
+# ---------------------------------------------------------------------------
+
+
+def test_is_ollama_model_true_for_ollama_prefix() -> None:
+    assert is_ollama_model("ollama/llama3") is True
+    assert is_ollama_model("ollama/llava") is True
+    assert is_ollama_model("ollama_chat/llama3") is True
+    assert is_ollama_model("OLLAMA/llava") is True
+
+
+def test_is_ollama_model_false_otherwise() -> None:
+    assert is_ollama_model(None) is False
+    assert is_ollama_model("") is False
+    assert is_ollama_model("gpt-4o") is False
+    assert is_ollama_model("anthropic/claude-3-haiku") is False
+    assert is_ollama_model("llama3") is False  # no provider prefix
+
+
+# ---------------------------------------------------------------------------
+# ollama_direct_completion — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_strips_provider_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert captured["json"]["model"] == "llava"
+
+
+def test_strips_ollama_chat_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama_chat/llama3",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert captured["json"]["model"] == "llama3"
+
+
+def test_passes_temperature_and_streaming_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0,
+    )
+
+    assert captured["json"]["stream"] is False
+    assert captured["json"]["options"]["temperature"] == 0.0
+
+
+def test_default_api_base_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BSP_HYBRID_API_BASE", raising=False)
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert captured["url"] == "http://localhost:11434/api/chat"
+
+
+def test_explicit_api_base_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BSP_HYBRID_API_BASE", "http://wrong:1234")
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+        api_base="http://right:11434",
+    )
+
+    assert captured["url"] == "http://right:11434/api/chat"
+
+
+def test_env_api_base_used_when_no_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "BSP_HYBRID_API_BASE", "http://host.docker.internal:11434"
+    )
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert captured["url"].startswith("http://host.docker.internal")
+
+
+def test_returns_openai_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(
+        monkeypatch,
+        response_payload={
+            "message": {
+                "role": "assistant",
+                "content": '{"transactions": [{"x": 1}]}',
+            }
+        },
+    )
+
+    result = ollama_direct_completion(
+        model="ollama/llava",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert "choices" in result
+    assert (
+        result["choices"][0]["message"]["content"]
+        == '{"transactions": [{"x": 1}]}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multimodal message conversion
+# ---------------------------------------------------------------------------
+
+
+def test_unpacks_multimodal_content_into_ollama_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    img_b64 = base64.b64encode(b"PNG_BYTES").decode("ascii")
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[
+            {"role": "system", "content": "You are a parser."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Extract this:"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/png;base64,{img_b64}",
+                        },
+                    },
+                ],
+            },
+        ],
+    )
+
+    sent_messages = captured["json"]["messages"]
+    assert sent_messages[0] == {
+        "role": "system",
+        "content": "You are a parser.",
+    }
+    user = sent_messages[1]
+    assert user["role"] == "user"
+    assert user["content"] == "Extract this:"
+    assert user["images"] == [img_b64]
+
+
+def test_accepts_raw_base64_images_without_data_url_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    img_b64 = base64.b64encode(b"PNG_BYTES").decode("ascii")
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": img_b64},
+                    },
+                ],
+            }
+        ],
+    )
+
+    assert captured["json"]["messages"][0]["images"] == [img_b64]
+
+
+def test_skips_unknown_content_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_httpx(monkeypatch, capture=captured)
+
+    ollama_direct_completion(
+        model="ollama/llava",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "alpha"},
+                    {"type": "video_url", "video_url": {"url": "x"}},
+                    "not a dict",
+                    {"type": "text", "text": "beta"},
+                ],
+            }
+        ],
+    )
+
+    assert captured["json"]["messages"][0]["content"] == "alpha\nbeta"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_raises_when_model_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(monkeypatch)
+    with pytest.raises(OllamaDirectError, match="model is required"):
+        ollama_direct_completion(messages=[{"role": "user", "content": "hi"}])
+
+
+def test_raises_when_messages_missing_or_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(monkeypatch)
+    with pytest.raises(
+        OllamaDirectError, match="messages must be a non-empty list"
+    ):
+        ollama_direct_completion(model="ollama/llava")
+    with pytest.raises(
+        OllamaDirectError, match="messages must be a non-empty list"
+    ):
+        ollama_direct_completion(model="ollama/llava", messages=[])
+
+
+def test_raises_on_unsupported_content_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(monkeypatch)
+    with pytest.raises(
+        OllamaDirectError, match="Unsupported message content type"
+    ):
+        ollama_direct_completion(
+            model="ollama/llava",
+            messages=[{"role": "user", "content": 42}],
+        )
+
+
+def test_raises_on_invalid_raw_base64_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(monkeypatch)
+    with pytest.raises(
+        OllamaDirectError, match="Invalid image_url payload"
+    ):
+        ollama_direct_completion(
+            model="ollama/llava",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "!!!not-base64!!!"},
+                        }
+                    ],
+                }
+            ],
+        )
+
+
+def test_wraps_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(
+        monkeypatch, raise_on_post=ConnectionError("refused")
+    )
+    with pytest.raises(
+        OllamaDirectError, match="Direct Ollama call failed"
+    ):
+        ollama_direct_completion(
+            model="ollama/llava",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+def test_wraps_unexpected_response_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_httpx(
+        monkeypatch, response_payload={"unexpected": "shape"}
+    )
+    with pytest.raises(
+        OllamaDirectError, match="Unexpected Ollama response shape"
+    ):
+        ollama_direct_completion(
+            model="ollama/llava",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Auto-selection in extractors
+# ---------------------------------------------------------------------------
+
+
+def test_vision_extractor_auto_selects_direct_bridge_for_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from bankstatementparser.hybrid.vision import VisionExtractor
+
+    _install_fake_httpx(monkeypatch)
+    ext = VisionExtractor(model="ollama/llava")
+    fn = ext._resolve_completion()
+    assert fn is od.ollama_direct_completion
+
+
+def test_llm_extractor_auto_selects_direct_bridge_for_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from bankstatementparser.hybrid.llm_extractor import LLMExtractor
+
+    _install_fake_httpx(monkeypatch)
+    ext = LLMExtractor(model="ollama/llama3")
+    fn = ext._resolve_completion()
+    assert fn is od.ollama_direct_completion
+
+
+def test_extractors_skip_direct_bridge_for_non_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from bankstatementparser.hybrid.llm_extractor import LLMExtractor
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = lambda **_: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    ext = LLMExtractor(model="anthropic/claude-3-haiku")
+    fn = ext._resolve_completion()
+    assert fn is fake_litellm.completion

--- a/tests/test_hybrid_ollama_direct.py
+++ b/tests/test_hybrid_ollama_direct.py
@@ -190,7 +190,10 @@ def test_env_api_base_used_when_no_explicit_override(
         messages=[{"role": "user", "content": "hi"}],
     )
 
-    assert captured["url"].startswith("http://host.docker.internal")
+    assert (
+        captured["url"]
+        == "http://host.docker.internal:11434/api/chat"
+    )
 
 
 def test_returns_openai_envelope(

--- a/tests/test_hybrid_vision.py
+++ b/tests/test_hybrid_vision.py
@@ -349,3 +349,288 @@ def test_vision_module_exports_error_subclass() -> None:
         vision_mod.VisionExtractorError,
         vision_mod.LLMExtractorError,
     )
+
+
+# ---------------------------------------------------------------------------
+# strip_rows mode (improvement #3)
+# ---------------------------------------------------------------------------
+
+
+class _FakePil:
+    def __init__(self, width: int = 800, height: int = 1200) -> None:
+        self.size = (width, height)
+
+    def crop(self, _box: Any) -> _FakePil:
+        return _FakePil(self.size[0], 100)
+
+    def save(self, buffer: Any, format: str) -> None:  # noqa: A002
+        buffer.write(b"PNG_STRIP")
+
+
+class _FakeBitmapPil:
+    def to_pil(self) -> _FakePil:
+        return _FakePil()
+
+
+class _FakePageStrip:
+    def render(self, scale: float) -> _FakeBitmapPil:  # noqa: ARG002
+        return _FakeBitmapPil()
+
+
+def _install_fake_pdfium_strip(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    page_count: int = 1,
+) -> None:
+    module = types.ModuleType("pypdfium2")
+
+    class _Doc:
+        def __init__(self, _path: str) -> None:
+            self._pages = [_FakePageStrip() for _ in range(page_count)]
+
+        def __len__(self) -> int:
+            return len(self._pages)
+
+        def __getitem__(self, idx: int) -> _FakePageStrip:
+            return self._pages[idx]
+
+    module.PdfDocument = _Doc  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypdfium2", module)
+
+
+def test_strip_extractor_calls_completion_per_strip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from decimal import Decimal
+
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+    _install_fake_pdfium_strip(monkeypatch, page_count=1)
+
+    call_count = {"n": 0}
+    captured_messages: list[Any] = []
+
+    def fake_completion(**kwargs: Any) -> Any:
+        call_count["n"] += 1
+        captured_messages.append(kwargs["messages"])
+        if call_count["n"] == 1:
+            payload = {
+                "account_id": "12345678",
+                "currency": "GBP",
+                "opening_balance": "1500.00",
+                "closing_balance": "1450.00",
+                "transactions": [
+                    {
+                        "booking_date": "2026-04-01",
+                        "description": "Header tx",
+                        "amount": -10.00,
+                        "confidence": 0.9,
+                    }
+                ],
+            }
+        elif call_count["n"] == 2:
+            payload = {
+                "transactions": [
+                    {
+                        "booking_date": "2026-04-02",
+                        "description": "Body tx A",
+                        "amount": -20.00,
+                        "confidence": 0.85,
+                    }
+                ]
+            }
+        elif call_count["n"] == 3:
+            payload = {
+                "transactions": [
+                    {
+                        "booking_date": "2026-04-03",
+                        "description": "Body tx B",
+                        "amount": -10.00,
+                        "confidence": 0.85,
+                    }
+                ]
+            }
+        else:
+            # Last strip — re-emit "Body tx A" verbatim to exercise
+            # the transaction_hash dedup logic.
+            payload = {
+                "transactions": [
+                    {
+                        "booking_date": "2026-04-02",
+                        "description": "Body tx A",
+                        "amount": -20.00,
+                        "confidence": 0.85,
+                    }
+                ]
+            }
+        return {
+            "choices": [{"message": {"content": json.dumps(payload)}}]
+        }
+
+    extractor = VisionExtractor(
+        model="ollama/minicpm-v",
+        completion_fn=fake_completion,
+        strip_rows=True,
+        n_strips=4,
+    )
+    result = extractor.extract(pdf_path)
+
+    assert call_count["n"] == 4
+    assert result.account_id == "12345678"
+    assert result.currency == "GBP"
+    assert result.opening_balance == Decimal("1500.00")
+    assert result.closing_balance == Decimal("1450.00")
+    descriptions = [tx.description for tx in result.transactions]
+    assert descriptions == ["Header tx", "Body tx A", "Body tx B"]
+    assert "TOP STRIP" in captured_messages[0][0]["content"]
+    assert "HORIZONTAL BAND" in captured_messages[1][0]["content"]
+
+
+def test_strip_extractor_rejects_n_strips_below_two() -> None:
+    with pytest.raises(ValueError, match="at least 2"):
+        VisionExtractor(
+            model="ollama/minicpm-v",
+            completion_fn=lambda **_: None,
+            strip_rows=True,
+            n_strips=1,
+        )
+
+
+def test_strip_extractor_raises_when_no_strips_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "empty.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+    _install_fake_pdfium_strip(monkeypatch, page_count=0)
+
+    extractor = VisionExtractor(
+        model="ollama/minicpm-v",
+        completion_fn=lambda **_: None,
+        strip_rows=True,
+    )
+    with pytest.raises(VisionExtractorError, match="No strips rendered"):
+        extractor.extract(pdf_path)
+
+
+def test_strip_extractor_open_pdf_failure_wrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+
+    fake = types.ModuleType("pypdfium2")
+
+    def _doc(_path: str) -> Any:
+        raise RuntimeError("cannot open")
+
+    fake.PdfDocument = _doc  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypdfium2", fake)
+
+    extractor = VisionExtractor(
+        model="ollama/minicpm-v",
+        completion_fn=lambda **_: None,
+        strip_rows=True,
+    )
+    with pytest.raises(VisionExtractorError, match="Failed to open"):
+        extractor.extract(pdf_path)
+
+
+def test_strip_extractor_render_failure_wrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+
+    class _BoomPage:
+        def render(self, scale: float) -> Any:  # noqa: ARG002
+            raise RuntimeError("render boom")
+
+    fake = types.ModuleType("pypdfium2")
+
+    class _Doc:
+        def __init__(self, _path: str) -> None:
+            self._pages = [_BoomPage()]
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, idx: int) -> _BoomPage:
+            return self._pages[idx]
+
+    fake.PdfDocument = _Doc  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypdfium2", fake)
+
+    extractor = VisionExtractor(
+        model="ollama/minicpm-v",
+        completion_fn=lambda **_: None,
+        strip_rows=True,
+    )
+    with pytest.raises(VisionExtractorError, match="render"):
+        extractor.extract(pdf_path)
+
+
+def test_strip_extractor_crop_failure_wrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+
+    class _BadPil:
+        size = (800, 1200)
+
+        def crop(self, _box: Any) -> Any:
+            raise RuntimeError("crop boom")
+
+    class _BadBitmap:
+        def to_pil(self) -> _BadPil:
+            return _BadPil()
+
+    class _Page:
+        def render(self, scale: float) -> _BadBitmap:  # noqa: ARG002
+            return _BadBitmap()
+
+    fake = types.ModuleType("pypdfium2")
+
+    class _Doc:
+        def __init__(self, _path: str) -> None:
+            self._pages = [_Page()]
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, idx: int) -> _Page:
+            return self._pages[idx]
+
+    fake.PdfDocument = _Doc  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypdfium2", fake)
+
+    extractor = VisionExtractor(
+        model="ollama/minicpm-v",
+        completion_fn=lambda **_: None,
+        strip_rows=True,
+    )
+    with pytest.raises(VisionExtractorError, match="strip"):
+        extractor.extract(pdf_path)
+
+
+def test_build_strip_messages_header_vs_body_prompt() -> None:
+    from bankstatementparser.hybrid.vision import _build_strip_messages
+
+    header = _build_strip_messages(
+        b"PNG", strip_index=0, total_strips=4, include_balances=True
+    )
+    body = _build_strip_messages(
+        b"PNG", strip_index=2, total_strips=4, include_balances=False
+    )
+    assert "TOP STRIP" in header[0]["content"]
+    assert "HORIZONTAL BAND" in body[0]["content"]
+    assert (
+        header[1]["content"][1]["image_url"]["url"].startswith(
+            "data:image/png;base64,"
+        )
+    )
+    assert (
+        body[1]["content"][1]["image_url"]["url"].startswith(
+            "data:image/png;base64,"
+        )
+    )


### PR DESCRIPTION
## Summary

Release **v0.0.7 "Universal Vision"** — turns the local Ollama vision path from 🔴 (600 s LiteLLM timeout, hallucinated output) to 🟢 (all 11 rows extracted in ~33 s, correct currency and balances) on every supported platform.

Three independent improvements, all verified end-to-end against real local Ollama models on Apple Silicon:

| # | Improvement | Effect |
|---|---|---|
| **1** | Built-in direct Ollama bridge (`ollama_direct.py`) | Bypasses the upstream LiteLLM ↔ Ollama integration bug. `ollama/llava` v0.0.6: **600 s timeout** → v0.0.7: **~18 s, completes**. Auto-selected for any `ollama/*` model — zero user action required. |
| **2** | `ollama/minicpm-v` recommended default | Document-specialized OCR model replaces general-purpose `llava`. `ollama/llava`: hallucinates INR currency → `ollama/minicpm-v`: **all 11 rows, GBP, balances correct, ~33 s**. |
| **3** | `VisionExtractor(strip_rows=True)` | Splits each page into N overlapping horizontal strips, one LLM call per strip. Header strip extracts balances; body strips extract rows; results merged by `transaction_hash`. Fixes sign-flip errors on small local models. |

**API impact:** zero breaking changes. Existing v0.0.5/v0.0.6 code that constructs `VisionExtractor(model="ollama/llava")` keeps working — it just runs ~33 s faster instead of hanging. `strip_rows` defaults to `False`.

This PR contains **7 commits** across **15 files** with **+1,467 / −43 lines**, rebased cleanly onto v0.0.6 (`main`).

## New module: `bankstatementparser.hybrid.ollama_direct`

A ~220-line drop-in replacement for `litellm.completion` that targets Ollama's `/api/chat` endpoint via `httpx`.

```python
from bankstatementparser.hybrid import ollama_direct_completion, is_ollama_model

# Automatically used when model starts with "ollama/" — no opt-in needed
# Or call directly:
response = ollama_direct_completion(
    model="ollama/minicpm-v",
    messages=[{"role": "user", "content": "..."}],
)
```

**Why it exists:** LiteLLM's Ollama adapter has a reproducible bug where vision calls with long structured-JSON system prompts hang at the 600 s timeout. The same prompt sent directly to Ollama's `/api/chat` completes in ~18 s. Verified during the v0.0.5 smoke test — short prompts work fine through LiteLLM; only long system prompts hang.

**Auto-selection:** Both `VisionExtractor` and `LLMExtractor` check `is_ollama_model(self.model)` inside `_resolve_completion()` and return `ollama_direct_completion` automatically when no explicit `completion_fn` was passed. Users who need to keep using LiteLLM (e.g. for a proxy) pass `completion_fn=litellm.completion` explicitly.

**Public API:**
- `ollama_direct_completion(**kwargs)` — accepts OpenAI-style messages (including multimodal `image_url` blocks), returns OpenAI-style response envelope
- `is_ollama_model(model)` — returns `True` for `ollama/<name>` or `ollama_chat/<name>`
- `OllamaDirectError` — narrow exception type
- No new optional dependencies — `httpx` is already a transitive dep of LiteLLM in `[hybrid]`

## New feature: `VisionExtractor(strip_rows=True)`

```python
from bankstatementparser.hybrid import VisionExtractor, smart_ingest

# For dense pages (≥15 rows) where small local models can't process the full page
vision = VisionExtractor(strip_rows=True, n_strips=4)
result = smart_ingest("dense_statement.pdf", vision_extractor=vision)
```

Splits each PDF page into `n_strips` overlapping horizontal strips (`STRIP_OVERLAP_FRACTION = 0.10`). Strip 0 gets a "header" prompt asking for `account_id`, `currency`, and balances. Subsequent strips get a "body" prompt asking for transactions only. Results are merged via `Transaction.transaction_hash` so rows that bisect a strip boundary are dedup'd automatically.

**New constants:** `DEFAULT_STRIP_COUNT = 4`, `STRIP_OVERLAP_FRACTION = 0.10`

**New prompts:** `STRIP_HEADER_SYSTEM_PROMPT` (for strip 0) and `STRIP_BODY_SYSTEM_PROMPT` (for body strips) — separate from the existing full-page `VISION_SYSTEM_PROMPT` which remains the default for `strip_rows=False`.

## Smoke-test results (real Ollama models, Apple Silicon)

### v0.0.7

| Path | Model | Mode | Result |
|---|---|---|---|
| Text-LLM | `ollama/llama3` (4.7 GB) | single-shot | ✅ All 11 rows, `confidence=1.00`, **VERIFIED**, ~25 s |
| Vision-LLM | `ollama/minicpm-v:8b` (5.5 GB) | **single-shot** | ✅ All 11 rows, `GBP`, balances correct, **~33 s**. Two sign-flip errors fixable via strip mode. |
| Vision-LLM | `ollama/minicpm-v:8b` (5.5 GB) | **strip_rows=True** | ✅ Sign convention correct, all 11 rows, ~43 s (4 LLM calls). |

### v0.0.5/v0.0.6 baseline

| Path | Model | Result |
|---|---|---|
| Vision-LLM | `ollama/llava:7b` (4.7 GB) | 🔴 600 s LiteLLM timeout. Direct Ollama call: 18 s but hallucinates (INR, fake rows). |

## Files changed (7 commits, 15 files, +1,467 / −43 lines)

| File | Change |
|---|---|
| `bankstatementparser/hybrid/ollama_direct.py` | **NEW** — 219 lines. Direct Ollama bridge with message conversion, base64 image handling, error wrapping. |
| `bankstatementparser/hybrid/vision.py` | +315 lines. `strip_rows`/`n_strips` parameters, `_render_strips()`, `_extract_strip()`, `_call_vision()` refactor, `_build_strip_messages()`, `STRIP_HEADER_SYSTEM_PROMPT`, `STRIP_BODY_SYSTEM_PROMPT`, `DEFAULT_STRIP_COUNT`, `STRIP_OVERLAP_FRACTION`. Auto-selection of `ollama_direct_completion` in `_resolve_completion()`. |
| `bankstatementparser/hybrid/llm_extractor.py` | +12 lines. Auto-selection of `ollama_direct_completion` for parity with vision. |
| `bankstatementparser/hybrid/__init__.py` | +8 lines. Exports `OllamaDirectError`, `is_ollama_model`, `ollama_direct_completion`. |
| `tests/test_hybrid_ollama_direct.py` | **NEW** — 447 lines. 21 tests covering bridge, message conversion, multimodal image handling, error paths, auto-selection in both extractors. |
| `tests/test_hybrid_vision.py` | +285 lines. 6 strip-mode tests + 1 strip-message-builder test covering happy path (4-strip dedup), `n_strips<2` rejection, empty render, open/render/crop failures. |
| `CHANGELOG.md` | +105 lines. Full v0.0.7 "Universal Vision" entry with Added/Changed/Smoke-test/Migration sections. |
| `FAQ.md` | +36 lines. Q13 rewritten for minicpm-v + ollama_direct bridge + strip mode. |
| `README.md` | +10 lines. Version badge, test count (672), module count (24). |
| `examples/hybrid/03_smart_ingest_vision.py` | +21 lines. Live-mode comment updated for v0.0.7 bridge + minicpm-v timing. |
| `examples/hybrid/README.md` | +42 lines. v0.0.7 smoke-test results table, "What v0.0.7 changed" section, updated troubleshooting entries, minicpm-v install instructions. |
| `pyproject.toml` | Version 0.0.6 → 0.0.7. |
| `setup.cfg` | Version 0.0.6 → 0.0.7. |
| `.github/SECURITY.md` | v0.0.7 added to Supported Versions. |
| `.github/workflows/quality-gates.yml` | `test_hybrid_ollama_direct.py` added to explicit test list. `httpx` added to mypy `ignore_missing_imports`. |

## Test plan

- [x] **677 tests pass** at 100% line + branch coverage (up from 649 on v0.0.6)
  - 21 new in `test_hybrid_ollama_direct.py` (bridge, message conversion, error paths, auto-selection)
  - 7 new in `test_hybrid_vision.py` (strip-mode happy path + dedup + error wrapping + prompt selection)
- [x] `mypy --strict` clean on 24 source files
- [x] `ruff check` + `bandit -r` clean
- [x] `make verify` (pre-commit hook) passes locally
- [x] **32 docs accuracy tests** all pass (test counts, module counts, example scripts, version badges, SECURITY.md version)
- [x] **All 5 hybrid Python examples** run end-to-end in mock mode
- [x] **Live Ollama smoke test** against `ollama/minicpm-v:8b`: single-shot ~33 s + strip mode ~43 s, documented in `examples/hybrid/README.md`
- [x] **CI: 44 SUCCESS / 1 SKIPPED / 0 FAILURE** on this PR

## Migration notes

Fully backwards compatible. Three upgrade patterns:

```python
# 1. Do nothing — existing code now works fast
result = smart_ingest("scan.pdf")  # auto-uses ollama_direct for ollama/* models

# 2. Switch to the recommended local vision model
import os
os.environ["BSP_HYBRID_VISION_MODEL"] = "ollama/minicpm-v"  # was "ollama/llava"

# 3. Enable strip mode for dense pages
from bankstatementparser.hybrid import VisionExtractor, smart_ingest
vision = VisionExtractor(strip_rows=True, n_strips=4)
result = smart_ingest("dense_statement.pdf", vision_extractor=vision)
```

To keep using LiteLLM (e.g. behind a proxy): `VisionExtractor(completion_fn=litellm.completion)`.

## Commit history (7 commits, all SSH-signed)

```
6787c90 docs: update counts + SECURITY.md for v0.0.7 post-rebase
59bc348 test: replace startswith() URL check with exact equality
8771bd7 ci: collect test_hybrid_ollama_direct.py in unit-tests workflow
bb44c53 ci: add httpx to mypy ignore_missing_imports
c85e744 docs(v0.0.7): minicpm-v default + smoke-test results + version bump
e535653 test(hybrid): strip-mode tests for VisionExtractor
8dd67c6 feat(hybrid): direct Ollama bridge bypasses LiteLLM long-prompt hang
```