### PR TITLE
fix(hybrid): add UNVERIFIABLE status + clearer deterministic-detection warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- New `VerificationStatus.UNVERIFIABLE` member for statements that
+  **cannot** be checked (missing opening/closing balance, fewer than
+  two statements for a continuity check, or multi-currency balances
+  that cannot be attributed to one currency). It sits between
+  `DISCREPANCY` and `FAILED` in the aggregate worst-first precedence:
+  `DISCREPANCY` > `FAILED` > `UNVERIFIABLE` > `VERIFIED`.
+
+### Changed
+
+- **Behavior change.** The "cannot apply the rule" cases that
+  previously reported `FAILED` now report `UNVERIFIABLE`:
+  `verify_balance`/`verify_transactions` with a missing
+  opening/closing balance, `verify_balance_multi_currency` with no (or
+  partial) per-currency balances, and `verify_continuity` with fewer
+  than two statements or a missing balance on a link. `FAILED` is now
+  reserved for a genuine verification error — no current code path
+  emits it. **Migration:** code that matched `status == FAILED` for
+  the missing-balance / cannot-verify case must now match
+  `status == UNVERIFIABLE`.
+- Review mode (`--type review`) now also routes `UNVERIFIABLE`
+  statements to human review, not only `DISCREPANCY`/`FAILED` — a
+  statement we could not verify should still be reviewed.
+- Reworded the hybrid orchestrator's deterministic-detection warning.
+  Instead of the misleading "Format detection failed: ..." (which read
+  like an error for every PDF), it now emits a clear routing message —
+  "No deterministic statement format matched (not XML/CSV/OFX/QFX/
+  MT940); routing to the hybrid LLM/vision extraction pipeline" — and
+  demotes the raw detector detail to `DEBUG` logging.
 
 ## [0.0.9] — 2026-06-11
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@
 
 ### 3. Is the extraction process deterministic?
 
-**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 818 tests, including property-based fuzzing via Hypothesis.
+**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 820 tests, including property-based fuzzing via Hypothesis.
 
 The v0.0.5 hybrid pipeline (`smart_ingest()`) extends this with two LLM fallbacks for PDFs that have no structured equivalent. Those paths are explicitly tagged as non-deterministic via `source_method='llm'` or `'vision'` on every extracted `Transaction` so audit trails can distinguish "facts from source" from "AI-inferred". The deterministic core is unchanged.
 
@@ -168,7 +168,7 @@ The full smoke-test results table is in `examples/hybrid/README.md` under "Smoke
 3. **You're passing manual balance overrides that don't match the file's actual balances.** Drop the overrides and let the LLM read them from the document.
 4. **Currency mismatch on a multi-currency statement.** The Golden Rule sums all amounts as if they were in the same currency. Multi-currency statements need per-currency verification — out of scope for v0.0.5; deferred to v0.0.6 (see [#46](https://github.com/sebastienrousseau/bankstatementparser/issues/46)).
 
-When in doubt, switch the verification status to `FAILED` (don't import) and queue the statement for human review. The v0.0.6 review-mode UI ([#45](https://github.com/sebastienrousseau/bankstatementparser/issues/45)) will surface these cases via the `raw_source_text` field that v0.0.5 already populates.
+When in doubt, switch the verification status to `UNVERIFIABLE` (don't import) and queue the statement for human review. The v0.0.6 review-mode UI ([#45](https://github.com/sebastienrousseau/bankstatementparser/issues/45)) will surface these cases via the `raw_source_text` field that v0.0.5 already populates.
 
 ---
 
@@ -184,7 +184,7 @@ Bank Statement Parser is designed for environments where auditability is non-neg
 To verify reproducibility locally:
 
 ```bash
-poetry run pytest                             # 818 tests, coverage gated in CI
+poetry run pytest                             # 820 tests, coverage gated in CI
 poetry run python scripts/verify_locked_hashes.py   # SHA-256 hash verification
 git log --show-signature -1                   # Verify commit signature
 ```

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ print(result.source_method)         # "deterministic"
 # Path B — text-LLM for digital PDFs (set BSP_HYBRID_MODEL=ollama/llama3)
 result = smart_ingest("statement.pdf")
 print(result.source_method)         # "llm"
-print(result.verification.status)   # VERIFIED | DISCREPANCY | FAILED
+print(result.verification.status)   # VERIFIED | DISCREPANCY | UNVERIFIABLE | FAILED
 
 # Path C — multimodal vision for scanned PDFs (set BSP_HYBRID_VISION_MODEL)
 # auto-routed when pypdf cannot extract enough text
@@ -273,7 +273,7 @@ flowchart TD
     Z --> V[verify_balance<br/>Golden Rule]
     Y --> V
     X --> V
-    V --> R[VERIFIED / DISCREPANCY / FAILED]
+    V --> R[VERIFIED / DISCREPANCY / UNVERIFIABLE / FAILED]
 ```
 
 Every extracted row carries an immutable `transaction_hash`, an
@@ -311,7 +311,7 @@ for the full surface.
 
 | Feature | Description |
 |---|---|
-| **Golden Rule verification** *(v0.0.5)* | Every result carries `opening + credits − debits == closing` status: `VERIFIED`, `DISCREPANCY`, or `FAILED`. |
+| **Golden Rule verification** *(v0.0.5)* | Every result carries `opening + credits − debits == closing` status: `VERIFIED`, `DISCREPANCY`, `UNVERIFIABLE`, or `FAILED`. |
 | **Multi-currency verification** *(v0.0.8)* | `verify_balance_multi_currency()` groups transactions by currency and runs the Golden Rule independently per group — no more false `DISCREPANCY` on multi-currency statements. |
 | **Idempotent dedup** *(v0.0.5)* | Every `Transaction` carries a stable `transaction_hash` (MD5 of date + normalized description + amount). `Deduplicator.dedupe_by_hash()` makes incremental ingestion safe to re-run. |
 | **Interactive review** *(v0.0.6)* | `--type review` CLI walks through discrepancies with accept/edit/skip/delete/quit. `IngestResult.to_json()` / `.from_json()` for stable round-trip with embedded audit trail. |
@@ -332,7 +332,7 @@ for the full surface.
 |---|---|
 | **PII redaction** | Names, IBANs, and addresses masked by default — opt in with `--show-pii` |
 | **Secure ZIP** | `iter_secure_xml_entries()` rejects zip bombs, encrypted entries, and suspicious compression ratios |
-| **Tested** | 818 tests, coverage gated at 100% in CI, property-based fuzzing with Hypothesis |
+| **Tested** | 820 tests, coverage gated at 100% in CI, property-based fuzzing with Hypothesis |
 
 ---
 
@@ -685,7 +685,7 @@ bankstatementparser/api.py      REST API microservice (FastAPI)
 docs/compliance/                ISO 13485 validation, risk register, traceability matrix
 examples/                       14 deterministic + 8 hybrid runnable example scripts
 scripts/                        SBOM generation, checksums, signature verification
-tests/                          818 tests (unit, integration, property-based, security, hybrid mocks)
+tests/                          820 tests (unit, integration, property-based, security, hybrid mocks)
 ```
 
 ---

--- a/bankstatementparser/cli.py
+++ b/bankstatementparser/cli.py
@@ -450,9 +450,11 @@ class BankStatementCLI:
         (when that file is JSON) or any other source that emits an
         :class:`~bankstatementparser.hybrid.IngestResult` via its
         ``to_json()`` method. When the statement-level status is
-        :class:`VerificationStatus.DISCREPANCY` or
-        :class:`VerificationStatus.FAILED`, every transaction is
-        reviewed. Independently, ``review_below`` routes individual
+        :class:`VerificationStatus.DISCREPANCY`,
+        :class:`VerificationStatus.UNVERIFIABLE`, or
+        :class:`VerificationStatus.FAILED` (i.e. anything other than
+        ``VERIFIED``), every transaction is reviewed. Independently,
+        ``review_below`` routes individual
         low-confidence rows into the same flow even when the
         statement verified cleanly. The operator is prompted with a
         single-character action menu:

--- a/bankstatementparser/hybrid/orchestrator.py
+++ b/bankstatementparser/hybrid/orchestrator.py
@@ -316,7 +316,16 @@ def _safe_detect(file_path: Path, warnings: list[str]) -> Optional[str]:
     try:
         return detect_statement_format(str(file_path))
     except Exception as exc:
-        warnings.append(f"Format detection failed: {exc}")
+        logger.debug(
+            "Deterministic format detection did not match for %s: %s",
+            file_path,
+            exc,
+        )
+        warnings.append(
+            "No deterministic statement format matched "
+            "(not XML/CSV/OFX/QFX/MT940); routing to the hybrid "
+            "LLM/vision extraction pipeline"
+        )
         return None
 
 

--- a/bankstatementparser/hybrid/verification.py
+++ b/bankstatementparser/hybrid/verification.py
@@ -16,7 +16,7 @@
 """Golden Rule balance verification.
 
 If ``opening + credits - debits != closing`` the statement is flagged
-as ``Discrepancy`` (or ``Failed`` when balances are missing). This is
+as ``Discrepancy`` (or ``Unverifiable`` when balances are missing). This is
 the single most important integrity check in the hybrid pipeline.
 """
 
@@ -34,10 +34,25 @@ from ..transaction_models import Transaction
 
 
 class VerificationStatus(str, Enum):
-    """Verification outcome for a parsed statement."""
+    """Verification outcome for a parsed statement.
+
+    Members:
+        VERIFIED: The rule was applied and the books balance.
+        DISCREPANCY: The rule was applied and the books do **not**
+            balance.
+        UNVERIFIABLE: The rule could **not** be applied — e.g. a
+            missing opening/closing balance or fewer than two
+            statements for a continuity check. The statement is not
+            wrong; it simply cannot be checked, so it is routed to
+            human review.
+        FAILED: Reserved for a genuine verification error — the check
+            itself could not run. No current code path emits this; it
+            remains for forward compatibility and (de)serialization.
+    """
 
     VERIFIED = "verified"
     DISCREPANCY = "discrepancy"
+    UNVERIFIABLE = "unverifiable"
     FAILED = "failed"
 
 
@@ -76,7 +91,7 @@ def verify_balance(
 
     Returns:
         A :class:`BalanceVerification` describing the outcome. The
-        ``status`` is ``FAILED`` only when the rule cannot be applied
+        ``status`` is ``UNVERIFIABLE`` when the rule cannot be applied
         (missing balances), not when it disagrees.
     """
     credits = Decimal("0")
@@ -91,7 +106,7 @@ def verify_balance(
 
     if opening_balance is None or closing_balance is None:
         return BalanceVerification(
-            status=VerificationStatus.FAILED,
+            status=VerificationStatus.UNVERIFIABLE,
             opening_balance=opening_balance,
             closing_balance=closing_balance,
             total_credits=credits,
@@ -152,10 +167,10 @@ def verify_balance_multi_currency(
     Args:
         transactions: Iterable of normalized transactions.
         balances: Optional ``{currency: (opening, closing)}`` dict.
-            When ``None``, verification runs with ``FAILED`` status
-            for every currency (no balances provided). When a
+            When ``None``, verification runs with ``UNVERIFIABLE``
+            status for every currency (no balances provided). When a
             currency appears in the transactions but not in this
-            dict, its verification is also ``FAILED``.
+            dict, its verification is also ``UNVERIFIABLE``.
         tolerance: Per-currency tolerance. Defaults to one cent.
 
     Returns:
@@ -188,9 +203,11 @@ def aggregate_verifications(
 ) -> BalanceVerification:
     """Collapse per-currency results into one statement-level verdict.
 
-    The aggregate ``status`` is the worst per-currency outcome:
-    ``DISCREPANCY`` if any currency disagrees, else ``FAILED`` if any
-    currency could not be checked, else ``VERIFIED``.
+    The aggregate ``status`` is the worst per-currency outcome
+    (worst-first): ``DISCREPANCY`` if any currency disagrees, else
+    ``FAILED`` if any currency hit a genuine verification error, else
+    ``UNVERIFIABLE`` if any currency could not be checked, else
+    ``VERIFIED``.
 
     ``total_credits``/``total_debits``/``actual_delta`` are raw sums
     across all currencies — useful as row-count-style magnitudes, not
@@ -218,6 +235,8 @@ def aggregate_verifications(
         status = VerificationStatus.DISCREPANCY
     elif VerificationStatus.FAILED in statuses:
         status = VerificationStatus.FAILED
+    elif VerificationStatus.UNVERIFIABLE in statuses:
+        status = VerificationStatus.UNVERIFIABLE
     else:
         status = VerificationStatus.VERIFIED
 
@@ -286,13 +305,13 @@ def verify_continuity(
 
     Returns:
         A :class:`ContinuityResult`. ``status`` is ``DISCREPANCY``
-        if any link has a gap beyond tolerance, else ``FAILED`` if
-        any link could not be checked (missing balance on either
+        if any link has a gap beyond tolerance, else ``UNVERIFIABLE``
+        if any link could not be checked (missing balance on either
         side, or fewer than two statements), else ``VERIFIED``.
     """
     if len(statements) < 2:
         return ContinuityResult(
-            status=VerificationStatus.FAILED,
+            status=VerificationStatus.UNVERIFIABLE,
             breaks=(),
             checked_links=0,
             unchecked_links=0,
@@ -337,7 +356,7 @@ def verify_continuity(
         )
     if unchecked:
         return ContinuityResult(
-            status=VerificationStatus.FAILED,
+            status=VerificationStatus.UNVERIFIABLE,
             breaks=(),
             checked_links=checked,
             unchecked_links=unchecked,
@@ -374,8 +393,8 @@ def verify_transactions(
 
     The single ``opening_balance``/``closing_balance`` pair cannot
     be attributed to one currency of a multi-currency statement, so
-    in that case every currency reports ``FAILED`` (cannot verify)
-    rather than a spurious mismatch.
+    in that case every currency reports ``UNVERIFIABLE`` (cannot
+    verify) rather than a spurious mismatch.
 
     Args:
         transactions: Iterable of normalized transactions.

--- a/examples/hybrid/04_golden_rule.py
+++ b/examples/hybrid/04_golden_rule.py
@@ -9,7 +9,7 @@ the verifier can return:
 
   VERIFIED       arithmetic checks out within tolerance
   DISCREPANCY    arithmetic disagrees beyond tolerance
-  FAILED         the source did not provide both balances
+  UNVERIFIABLE   the source did not provide both balances
 
 Run from the repository root:
 
@@ -114,8 +114,8 @@ def main() -> int:
         opening_balance=None,
         closing_balance=None,
     )
-    _print("FAILED expected", result)
-    _expect(result.status, VerificationStatus.FAILED)
+    _print("UNVERIFIABLE expected", result)
+    _expect(result.status, VerificationStatus.UNVERIFIABLE)
     print("  -> Action: ask the operator to supply balances manually,")
     print("     or skip integrity check entirely (LLMs sometimes miss them).")
     print()

--- a/tests/test_hybrid_orchestrator.py
+++ b/tests/test_hybrid_orchestrator.py
@@ -165,9 +165,10 @@ def test_smart_ingest_multi_currency_avoids_false_discrepancy(
     )
     assert result.verification is not None
     # The single balance pair cannot be attributed to one currency,
-    # so the statement reports FAILED (cannot verify) instead of the
-    # false DISCREPANCY the summed single-currency check would give.
-    assert result.verification.status is VerificationStatus.FAILED
+    # so the statement reports UNVERIFIABLE (cannot verify) instead of
+    # the false DISCREPANCY the summed single-currency check would
+    # give.
+    assert result.verification.status is VerificationStatus.UNVERIFIABLE
     assert "Multi-currency statement" in result.verification.message
 
 
@@ -232,7 +233,11 @@ def test_smart_ingest_warns_when_detection_raises(
     )
     result = smart_ingest(file_path, extractor=extractor)
     assert result.source_method == "llm"
-    assert any("detection failed" in w for w in result.warnings)
+    assert any(
+        "No deterministic statement format matched" in w
+        for w in result.warnings
+    )
+    assert any("routing to the hybrid" in w for w in result.warnings)
 
 
 def test_smart_ingest_uses_llm_for_pdf_directly(
@@ -668,10 +673,43 @@ def test_ingest_result_round_trip_with_none_balance_fields() -> None:
     payload = original.to_json()
     restored = orchestrator.IngestResult.from_json(payload)
     assert restored.verification is not None
+    assert restored.verification.status is VerificationStatus.FAILED
     assert restored.verification.opening_balance is None
     assert restored.verification.closing_balance is None
     assert restored.verification.expected_delta is None
     assert restored.verification.discrepancy is None
+
+
+def test_ingest_result_round_trip_unverifiable_status() -> None:
+    """The UNVERIFIABLE status must round-trip through JSON."""
+    from bankstatementparser import Transaction
+    from bankstatementparser.hybrid.verification import (
+        BalanceVerification,
+        VerificationStatus,
+    )
+
+    verification = BalanceVerification(
+        status=VerificationStatus.UNVERIFIABLE,
+        opening_balance=None,
+        closing_balance=Decimal("10.00"),
+        total_credits=Decimal("10.00"),
+        total_debits=Decimal("0.00"),
+        expected_delta=None,
+        actual_delta=Decimal("10.00"),
+        discrepancy=None,
+        message="Cannot verify: missing opening or closing balance",
+    )
+    original = orchestrator.IngestResult(
+        source_method="llm",
+        source_format="pdf",
+        transactions=[Transaction(amount=Decimal("10.00"))],
+        verification=verification,
+    )
+
+    payload = original.to_json()
+    restored = orchestrator.IngestResult.from_json(payload)
+    assert restored.verification is not None
+    assert restored.verification.status is VerificationStatus.UNVERIFIABLE
 
 
 def test_ingest_result_from_json_skips_non_dict_audit_entries() -> None:

--- a/tests/test_hybrid_verification.py
+++ b/tests/test_hybrid_verification.py
@@ -52,23 +52,23 @@ def test_verify_balance_flags_discrepancy() -> None:
     assert "mismatch" in result.message
 
 
-def test_verify_balance_failed_when_balances_missing() -> None:
+def test_verify_balance_unverifiable_when_balances_missing() -> None:
     result = verify_balance(
         [_tx("10.00")],
         opening_balance=None,
         closing_balance=Decimal("10.00"),
     )
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE
     assert "missing" in result.message.lower()
 
 
-def test_verify_balance_failed_when_closing_missing() -> None:
+def test_verify_balance_unverifiable_when_closing_missing() -> None:
     result = verify_balance(
         [_tx("10.00")],
         opening_balance=Decimal("0"),
         closing_balance=None,
     )
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE
 
 
 def test_verify_continuity_verified_when_chain_matches() -> None:
@@ -119,21 +119,21 @@ def test_verify_continuity_break_takes_precedence_over_missing() -> None:
     assert len(result.breaks) == 1
 
 
-def test_verify_continuity_failed_when_balance_missing() -> None:
+def test_verify_continuity_unverifiable_when_balance_missing() -> None:
     result = verify_continuity(
         [
             ("jan.xml", Decimal("100"), Decimal("250")),
             ("feb.xml", None, Decimal("300")),
         ]
     )
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE
     assert result.unchecked_links == 1
     assert "1 of 1 links missing a balance" in result.message
 
 
 def test_verify_continuity_needs_at_least_two_statements() -> None:
     result = verify_continuity([("jan.xml", Decimal("1"), Decimal("2"))])
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE
     assert result.checked_links == 0
     assert "at least two statements" in result.message
 

--- a/tests/test_multi_currency_verification.py
+++ b/tests/test_multi_currency_verification.py
@@ -10,6 +10,7 @@ import pytest
 
 from bankstatementparser import Transaction
 from bankstatementparser.hybrid.verification import (
+    BalanceVerification,
     VerificationStatus,
     aggregate_verifications,
     verify_balance_multi_currency,
@@ -23,6 +24,23 @@ def _tx(amount: str, currency: str, day: str = "2026-04-01") -> Transaction:
         currency=currency,
         booking_date=day,  # type: ignore[arg-type]
         description="x",
+    )
+
+
+def _balance_verification(
+    status: VerificationStatus,
+) -> BalanceVerification:
+    """Build a minimal BalanceVerification with the given status."""
+    return BalanceVerification(
+        status=status,
+        opening_balance=None,
+        closing_balance=None,
+        total_credits=Decimal("0"),
+        total_debits=Decimal("0"),
+        expected_delta=None,
+        actual_delta=Decimal("0"),
+        discrepancy=None,
+        message=status.value,
     )
 
 
@@ -62,28 +80,28 @@ def test_discrepancy_in_one_currency_does_not_affect_other() -> None:
     assert results["EUR"].status is VerificationStatus.DISCREPANCY
 
 
-def test_missing_currency_balance_returns_failed() -> None:
+def test_missing_currency_balance_returns_unverifiable() -> None:
     txs = [_tx("100.00", "GBP"), _tx("50.00", "USD")]
     results = verify_balance_multi_currency(
         txs,
         balances={"GBP": (Decimal("0"), Decimal("100"))},
     )
     assert results["GBP"].status is VerificationStatus.VERIFIED
-    assert results["USD"].status is VerificationStatus.FAILED
+    assert results["USD"].status is VerificationStatus.UNVERIFIABLE
 
 
 def test_none_currency_grouped_as_unknown() -> None:
     tx = Transaction(amount=Decimal("10.00"), description="x")
     results = verify_balance_multi_currency([tx])
     assert "UNKNOWN" in results
-    assert results["UNKNOWN"].status is VerificationStatus.FAILED
+    assert results["UNKNOWN"].status is VerificationStatus.UNVERIFIABLE
 
 
-def test_no_balances_returns_failed_for_all() -> None:
+def test_no_balances_returns_unverifiable_for_all() -> None:
     txs = [_tx("100.00", "GBP"), _tx("50.00", "EUR")]
     results = verify_balance_multi_currency(txs)
-    assert results["GBP"].status is VerificationStatus.FAILED
-    assert results["EUR"].status is VerificationStatus.FAILED
+    assert results["GBP"].status is VerificationStatus.UNVERIFIABLE
+    assert results["EUR"].status is VerificationStatus.UNVERIFIABLE
 
 
 def test_empty_input_returns_empty_dict() -> None:
@@ -128,7 +146,7 @@ def test_aggregate_all_verified_is_verified() -> None:
     assert "GBP" in aggregate.message
 
 
-def test_aggregate_discrepancy_wins_over_failed() -> None:
+def test_aggregate_discrepancy_wins_over_unverifiable() -> None:
     txs = [
         _tx("100.00", "GBP"),
         _tx("200.00", "EUR"),
@@ -141,7 +159,7 @@ def test_aggregate_discrepancy_wins_over_failed() -> None:
     assert aggregate.status is VerificationStatus.DISCREPANCY
 
 
-def test_aggregate_failed_when_any_currency_unverifiable() -> None:
+def test_aggregate_unverifiable_when_any_currency_unverifiable() -> None:
     txs = [
         _tx("100.00", "GBP"),
         _tx("200.00", "EUR"),
@@ -151,6 +169,21 @@ def test_aggregate_failed_when_any_currency_unverifiable() -> None:
         balances={"GBP": (Decimal("0"), Decimal("100"))},  # EUR missing
     )
     aggregate = aggregate_verifications(results)
+    assert aggregate.status is VerificationStatus.UNVERIFIABLE
+
+
+def test_aggregate_failed_takes_precedence_over_unverifiable() -> None:
+    """FAILED (genuine error) outranks UNVERIFIABLE but not DISCREPANCY."""
+    verified = _balance_verification(VerificationStatus.VERIFIED)
+    unverifiable = _balance_verification(VerificationStatus.UNVERIFIABLE)
+    failed = _balance_verification(VerificationStatus.FAILED)
+    aggregate = aggregate_verifications(
+        {
+            "GBP": verified,
+            "EUR": unverifiable,
+            "USD": failed,
+        }
+    )
     assert aggregate.status is VerificationStatus.FAILED
 
 
@@ -195,21 +228,22 @@ def test_verify_transactions_multi_currency_avoids_false_discrepancy() -> None:
         _tx("200.00", "EUR"),
     ]
     # Balances cannot be attributed to one currency: the statement
-    # reports FAILED (cannot verify) instead of a spurious mismatch.
+    # reports UNVERIFIABLE (cannot verify) instead of a spurious
+    # mismatch.
     result = verify_transactions(
         txs,
         opening_balance=Decimal("0"),
         closing_balance=Decimal("100"),
     )
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE
     assert "Multi-currency statement" in result.message
 
 
-def test_verify_transactions_missing_balances_failed() -> None:
+def test_verify_transactions_missing_balances_unverifiable() -> None:
     txs = [_tx("100.00", "GBP")]
     result = verify_transactions(
         txs,
         opening_balance=None,
         closing_balance=None,
     )
-    assert result.status is VerificationStatus.FAILED
+    assert result.status is VerificationStatus.UNVERIFIABLE

--- a/tests/test_regression_examples.py
+++ b/tests/test_regression_examples.py
@@ -193,7 +193,7 @@ def test_hybrid_04_golden_rule() -> None:
     out = _run_example(HYBRID_DIR / "04_golden_rule.py")
     assert "VERIFIED" in out
     assert "DISCREPANCY" in out
-    assert "FAILED" in out
+    assert "UNVERIFIABLE" in out
 
 
 def test_hybrid_05_dedupe_recurring() -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -180,12 +180,15 @@ def test_scan_continuity_none_for_single_file(tmp_path: Path) -> None:
     assert result.continuity is None
 
 
-def test_scan_continuity_failed_without_balances(tmp_path: Path) -> None:
+def test_scan_continuity_unverifiable_without_balances(
+    tmp_path: Path,
+) -> None:
     # Real fixtures ingested without balances: links exist but none
-    # can be checked, so the chain reports FAILED (cannot verify).
+    # can be checked, so the chain reports UNVERIFIABLE (cannot
+    # verify).
     shutil.copy(CAMT_FIXTURE, tmp_path / "a.xml")
     shutil.copy(CAMT_FIXTURE, tmp_path / "b.xml")
     result = scan_and_ingest(tmp_path)
     assert result.continuity is not None
-    assert result.continuity.status is VerificationStatus.FAILED
+    assert result.continuity.status is VerificationStatus.UNVERIFIABLE
     assert result.continuity.unchecked_links == 1


### PR DESCRIPTION
Two UX fixes surfaced while running the hybrid pipeline on real PDF statements.

## 1. `UNVERIFIABLE` verification status (stop overloading `FAILED`)
`FAILED` was reported both for a genuine problem **and** for "the Golden Rule can't be applied" (e.g. a statement with no opening balance) — which reads alarmingly when nothing actually broke. New status:

- **VERIFIED** — rule applied, books balance
- **DISCREPANCY** — rule applied, books don't balance
- **UNVERIFIABLE** *(new)* — rule could not be applied (missing opening/closing balance, `<2` statements)
- **FAILED** — reserved for a genuine verification error

Missing-balance / continuity cases now report `UNVERIFIABLE`. Review mode still routes `DISCREPANCY`/`FAILED`/`UNVERIFIABLE` to human review. `aggregate_verifications` precedence: `DISCREPANCY > FAILED > UNVERIFIABLE > VERIFIED`.

**Migration:** code matching `status == FAILED` for the missing-balance case should now match `UNVERIFIABLE`.

## 2. Clearer routing warning for PDFs
The deterministic detector raised `Format detection failed: …binary data, expected XML` on every PDF — it's not a failure, it's a routing decision. Now:
> No deterministic statement format matched (not XML/CSV/OFX/QFX/MT940); routing to the hybrid LLM/vision extraction pipeline

(raw detail demoted to `logger.debug`.)

## Validation
Found while running `smart_ingest` on 5 real-world PDF statements; re-ran after the fix — a no-opening-balance Lloyds debit report now correctly reads `UNVERIFIABLE` (was `FAILED`); a faint scan that dropped a ~£1,920 credit still correctly reads `DISCREPANCY`.

Gates: 837 passed, **100% coverage**, ruff + ruff format + mypy --strict clean, doc-accuracy + doc-regression green. Version stays 0.0.9 (changes under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)