### PR TITLE
audit: genuine 100% docs + honest 100% coverage (de-pragma)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `examples/hybrid/07_scan_and_ingest.py` example demonstrating
+  `scan_and_ingest()` over a directory of statements: cross-file
+  `transaction_hash` deduplication, the `ScanResult` summary, and the
+  cross-statement `verify_continuity()` integrity check.
+- `examples/hybrid/04_golden_rule.py` now also demonstrates
+  `verify_transactions()` (currency-aware Golden Rule) and
+  `verify_continuity()` (cross-statement chaining) alongside
+  `verify_balance()`.
+- `[tool.interrogate]` configuration enforcing **100% docstring
+  coverage** across the package, the helper `scripts/`, and the
+  runnable `examples/` (private and nested helpers included).
+- `tests/test_regression_examples.py::test_every_example_script_is_exercised`
+  asserts that every runnable script on disk is exercised by the
+  regression suite, so no example can be added without coverage.
+
+### Changed
+
+- Documentation-coverage audit: added docstrings to every previously
+  undocumented function, method, class, and nested helper (115 symbols
+  across the package, scripts, and examples) to reach 100% interrogate
+  coverage repo-wide.
+- Coverage-integrity audit: removed 27 of 29 `# pragma: no cover`
+  pragmas (and the unused `raise NotImplementedError` coverage
+  exclusion) by making the guarded behaviour genuinely testable and
+  adding the corresponding tests — covering the `/ingest` REST
+  endpoint, the API server entrypoint, the `pdfplumber` engine path,
+  the optional-dependency `ImportError` guards, the parallel
+  worker-crash path, and the `_coerce_transactions` fallbacks. The two
+  remaining pragmas are a provably-unreachable JSON guard and the
+  standard `if __name__ == "__main__"` entrypoint.
 - New `VerificationStatus.UNVERIFIABLE` member for statements that
   **cannot** be checked (missing opening/closing balance, fewer than
   two statements for a continuity check, or multi-currency balances

--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@
 
 ### 3. Is the extraction process deterministic?
 
-**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 820 tests, including property-based fuzzing via Hypothesis.
+**Yes — byte-identical output on every run for the deterministic path.** Given the same input file, `CamtParser`, `Pain001Parser`, `CsvStatementParser`, `OfxParser`, `Mt940Parser`, and `QfxParser` produce the same result every time. No randomness, no model inference, no heuristic sampling. Verify this yourself: run the same file twice and diff the output. CI enforces determinism with 844 tests, including property-based fuzzing via Hypothesis.
 
 The v0.0.5 hybrid pipeline (`smart_ingest()`) extends this with two LLM fallbacks for PDFs that have no structured equivalent. Those paths are explicitly tagged as non-deterministic via `source_method='llm'` or `'vision'` on every extracted `Transaction` so audit trails can distinguish "facts from source" from "AI-inferred". The deterministic core is unchanged.
 
@@ -184,7 +184,7 @@ Bank Statement Parser is designed for environments where auditability is non-neg
 To verify reproducibility locally:
 
 ```bash
-poetry run pytest                             # 820 tests, coverage gated in CI
+poetry run pytest                             # 844 tests, coverage gated in CI
 poetry run python scripts/verify_locked_hashes.py   # SHA-256 hash verification
 git log --show-signature -1                   # Verify commit signature
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ services unless they explicitly opt in.
 - [Command Line](#command-line) — console script and REST API
 - [Deduplication](#deduplication) — exact hashes + suspected matches
 - [Export](#export) — CSV, JSON, Excel, Polars, hledger, beancount
-- [Examples](#examples) — 22 runnable scripts (14 deterministic + 8 hybrid)
+- [Examples](#examples) — 23 runnable scripts (14 deterministic + 9 hybrid)
 - [XML Tag Mapping](#xml-tag-mapping) — ISO 20022 tags to DataFrame columns
 - [Ecosystem](#ecosystem) — companion packages (MCP, LSP, writers, loaders)
 
@@ -332,7 +332,7 @@ for the full surface.
 |---|---|
 | **PII redaction** | Names, IBANs, and addresses masked by default — opt in with `--show-pii` |
 | **Secure ZIP** | `iter_secure_xml_entries()` rejects zip bombs, encrypted entries, and suspicious compression ratios |
-| **Tested** | 820 tests, coverage gated at 100% in CI, property-based fuzzing with Hypothesis |
+| **Tested** | 844 tests, coverage gated at 100% in CI, property-based fuzzing with Hypothesis |
 
 ---
 
@@ -593,8 +593,8 @@ for currency, v in results.items():
 
 ## Examples
 
-See [`examples/`](examples/README.md) for 22 runnable scripts
-(14 deterministic + 8 hybrid):
+See [`examples/`](examples/README.md) for 23 runnable scripts
+(14 deterministic + 9 hybrid):
 
 ### Deterministic parsers
 
@@ -623,9 +623,11 @@ See [`examples/`](examples/README.md) for 22 runnable scripts
 | `hybrid/01_smart_ingest_deterministic.py` | Path A — `smart_ingest()` against a CAMT.053 fixture, $0 cost |
 | `hybrid/02_smart_ingest_text_llm.py` | Path B — text-LLM extraction from a digital PDF (mock or live Ollama) |
 | `hybrid/03_smart_ingest_vision.py` | Path C — multimodal vision extraction with `LOW_TEXT_DENSITY` auto-routing |
-| `hybrid/04_golden_rule.py` | All three `verify_balance()` outcomes |
+| `hybrid/04_golden_rule.py` | `verify_balance()`, `verify_transactions()`, and `verify_continuity()` across `VERIFIED` / `DISCREPANCY` / `UNVERIFIABLE` outcomes |
 | `hybrid/05_dedupe_recurring.py` | `normalize_description()` + `dedupe_by_hash()` for idempotent batching |
 | `hybrid/06_cli_walkthrough.sh` | Four flavours of the new `--type ingest` CLI subcommand |
+| `hybrid/06_cli_walkthrough.ps1` | PowerShell sibling of the bash walkthrough (native Windows) |
+| `hybrid/07_scan_and_ingest.py` | Bulk directory ingest with `scan_and_ingest()` — cross-file dedup + continuity check |
 
 See [`examples/hybrid/README.md`](examples/hybrid/README.md) for
 the full walkthrough including a Mermaid flow diagram, the
@@ -683,9 +685,9 @@ bankstatementparser/enrichment/ Categorizer, AccountMapper, EnrichedTransaction
 bankstatementparser/export/     hledger + beancount journal export
 bankstatementparser/api.py      REST API microservice (FastAPI)
 docs/compliance/                ISO 13485 validation, risk register, traceability matrix
-examples/                       14 deterministic + 8 hybrid runnable example scripts
+examples/                       14 deterministic + 9 hybrid runnable example scripts
 scripts/                        SBOM generation, checksums, signature verification
-tests/                          820 tests (unit, integration, property-based, security, hybrid mocks)
+tests/                          844 tests (unit, integration, property-based, security, hybrid mocks)
 ```
 
 ---

--- a/bankstatementparser/_llm_common.py
+++ b/bankstatementparser/_llm_common.py
@@ -56,6 +56,7 @@ _warned_destinations: set[tuple[str, str]] = set()
 
 
 def _is_local_api_base(api_base: Optional[str]) -> bool:
+    """Return whether an API base URL points at the local machine."""
     if not api_base:
         return True
     host = urlparse(api_base).hostname or ""

--- a/bankstatementparser/additional_parsers.py
+++ b/bankstatementparser/additional_parsers.py
@@ -118,6 +118,7 @@ CSV_COLUMN_GROUPS = {
 
 
 def _normalized_name(name: str) -> str:
+    """Fold a header name to lowercase ASCII alphanumerics for matching."""
     # NFKD + ASCII-encode folds accented characters to their base
     # letter (é -> e) so French/Spanish headers match their
     # unaccented synonym entries.
@@ -130,6 +131,7 @@ def _normalized_name(name: str) -> str:
 
 
 def _read_validated_text(file_name: str | Path) -> tuple[Path, str]:
+    """Validate the path and read its contents as UTF-8 text."""
     validator = InputValidator()
     path = validator.validate_input_file_path(str(file_name))
     try:
@@ -210,6 +212,7 @@ class CsvStatementParser(BankStatementParser):
         self._parsed_df: pd.DataFrame | None = None
 
     def _find_column(self, df: pd.DataFrame, logical_name: str) -> str | None:
+        """Return the DataFrame column matching a logical name, if any."""
         candidates = CSV_COLUMN_GROUPS[logical_name]
         for column in df.columns:
             column_name = str(column)
@@ -351,6 +354,7 @@ class OfxParser(BankStatementParser):
         self._parsed_df: pd.DataFrame | None = None
 
     def _tag_value(self, source: str, tag: str) -> str | None:
+        """Return the stripped value of an OFX/SGML tag, or None."""
         match = re.search(rf"<{tag}>([^<\r\n]+)", source, flags=re.IGNORECASE)
         if match is None:
             return None

--- a/bankstatementparser/api.py
+++ b/bankstatementparser/api.py
@@ -89,6 +89,7 @@ class APIError(RuntimeError):
 
 
 def _resolve_max_upload_bytes() -> int:
+    """Resolve the max upload size from the environment or default."""
     raw = os.environ.get(ENV_MAX_UPLOAD_BYTES)
     if not raw:
         return DEFAULT_MAX_UPLOAD_BYTES
@@ -121,6 +122,7 @@ def _safe_basename(filename: Optional[str]) -> str:
 
 
 def _allowed_suffix(name: str) -> bool:
+    """Return whether a filename has an allowed input extension."""
     suffix = Path(name).suffix
     if not suffix:
         return False
@@ -170,7 +172,7 @@ def create_app(
     _file_field = File(...)
 
     @app.post("/ingest")  # type: ignore[untyped-decorator]
-    async def ingest(  # pragma: no cover - async endpoint needs ASGI server
+    async def ingest(
         file: UploadFile = _file_field,
     ) -> JSONResponse:
         """Upload a bank statement and get structured JSON back.
@@ -277,6 +279,7 @@ def _result_to_dict(result: Any) -> dict[str, Any]:
 
 
 def _verification_dict(v: Any) -> Optional[dict[str, Any]]:
+    """Serialize a verification result to a JSON-safe dict, or None."""
     if v is None:
         return None
     return {
@@ -319,5 +322,5 @@ def main() -> None:
             "Install with: pip install 'bankstatementparser[api]'"
         ) from exc
 
-    app = create_app()  # pragma: no cover - server entrypoint
-    uvicorn.run(app, host=args.host, port=args.port)  # pragma: no cover
+    app = create_app()
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/bankstatementparser/cli.py
+++ b/bankstatementparser/cli.py
@@ -173,6 +173,7 @@ class BankStatementCLI:
         """
 
         def get_camt_stats(parser: Any) -> list[dict[str, Any]]:
+            """Return parser statistics as a list of dict rows."""
             data = parser.get_statement_stats()
             if isinstance(data, pd.DataFrame):
                 # list(DataFrame) would yield column names, not rows
@@ -375,7 +376,6 @@ class BankStatementCLI:
             )
             logger.error(f"Hybrid import failed: {exc}")
             sys.exit(1)
-            return  # pragma: no cover
 
         try:
             result = smart_ingest(str(file_path))
@@ -388,12 +388,10 @@ class BankStatementCLI:
             )
             logger.error(f"Hybrid runtime import failed: {exc}")
             sys.exit(1)
-            return  # pragma: no cover
         except Exception as exc:
             logger.error(f"Hybrid ingest failed: {exc}")
             print(f"Error: hybrid ingest failed - {exc}")
             sys.exit(1)
-            return  # pragma: no cover
 
         rows = [
             {
@@ -495,7 +493,6 @@ class BankStatementCLI:
             )
             logger.error(f"Hybrid import failed: {exc}")
             sys.exit(1)
-            return  # pragma: no cover
 
         try:
             payload = file_path.read_text(encoding="utf-8")
@@ -504,7 +501,6 @@ class BankStatementCLI:
             logger.error(f"Failed to load IngestResult: {exc}")
             print(f"Error: cannot load IngestResult JSON - {exc}")
             sys.exit(1)
-            return  # pragma: no cover
 
         v = result.verification
         review_all = v is not None and v.status is not (
@@ -758,10 +754,13 @@ class BankStatementCLI:
         try:
             args = self.parser.parse_args()
         except SystemExit:
-            # argparse failed, which means required arguments are missing
+            # argparse failed, which means required arguments are missing.
+            # The explicit return keeps the function from falling through
+            # to the (now unbound) ``args`` reference when ``sys.exit`` is
+            # patched in tests; in production ``sys.exit`` raises first.
             print("Error: Missing required arguments")
             sys.exit(1)
-            return  # pragma: no cover
+            return
 
         # Check if required arguments are present (safety check)
         if (

--- a/bankstatementparser/enrichment/categorizer.py
+++ b/bankstatementparser/enrichment/categorizer.py
@@ -178,6 +178,7 @@ def _build_messages(
     transactions: list[Transaction],
     schema: tuple[str, ...],
 ) -> list[dict[str, Any]]:
+    """Build the system/user message pair for a categorization call."""
     schema_block = "\n".join(f"  - {c}" for c in schema)
     rows = "\n".join(
         _format_row(idx, tx) for idx, tx in enumerate(transactions)
@@ -218,6 +219,7 @@ def _sanitize_for_prompt(value: str) -> str:
 
 
 def _format_row(index: int, tx: Transaction) -> str:
+    """Render one transaction as a single prompt line."""
     date = tx.booking_date.isoformat() if tx.booking_date else "????-??-??"
     desc = _sanitize_for_prompt(tx.description or "(no description)")
     return f"  [{index}] {date}  {tx.amount:>10}  {desc[:80]}"
@@ -331,6 +333,7 @@ class Categorizer:
         self,
         chunk: list[Transaction],
     ) -> list[EnrichedTransaction]:
+        """Categorize a single chunk of transactions via one LLM call."""
         completion = self._resolve_completion()
         messages = _build_messages(chunk, self.schema)
 
@@ -354,16 +357,17 @@ class Categorizer:
         return _build_enriched(chunk, payload, self._schema_lookup)
 
     def _resolve_completion(self) -> CompletionFn:
+        """Return the injected completion callable or import LiteLLM's."""
         if self.completion_fn is not None:
             return self.completion_fn
-        try:  # pragma: no cover - optional dep
+        try:
             from litellm import completion
-        except ImportError as exc:  # pragma: no cover - optional dep
+        except ImportError as exc:
             raise CategorizerError(
                 "litellm is required for the enrichment module. "
                 "Install with: pip install bankstatementparser[enrichment]"
             ) from exc
-        return completion  # type: ignore[no-any-return]  # pragma: no cover
+        return completion  # type: ignore[no-any-return]
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +381,7 @@ def _extract_message_content(response: Any) -> str:
 
 
 def _parse_json_payload(raw: str) -> dict[str, Any]:
+    """Tolerantly parse a JSON object from a model response."""
     return parse_json_payload(raw, error_cls=CategorizerError)
 
 
@@ -385,6 +390,7 @@ def _build_enriched(
     payload: dict[str, Any],
     schema_lookup: dict[str, str],
 ) -> list[EnrichedTransaction]:
+    """Map an LLM results payload back onto the input chunk by index."""
     raw_results = payload.get("results")
     if not isinstance(raw_results, list):
         raise CategorizerError("Enrichment payload missing 'results' list")

--- a/bankstatementparser/hybrid/evaluation.py
+++ b/bankstatementparser/hybrid/evaluation.py
@@ -102,6 +102,7 @@ class EvalSummary:
 
 
 def _to_decimal(value: object, *, context: str) -> Decimal:
+    """Coerce a value to ``Decimal``, raising on malformed input."""
     try:
         return Decimal(str(value))
     except InvalidOperation as exc:
@@ -109,12 +110,14 @@ def _to_decimal(value: object, *, context: str) -> Decimal:
 
 
 def _optional_decimal(value: object, *, context: str) -> Optional[Decimal]:
+    """Coerce a value to ``Decimal``, returning ``None`` when empty."""
     if value is None or value == "":
         return None
     return _to_decimal(value, context=context)
 
 
 def _optional_date(value: object, *, context: str) -> Optional[date]:
+    """Parse an ISO date, returning ``None`` when empty and raising on bad input."""
     if value is None or value == "":
         return None
     try:
@@ -243,6 +246,7 @@ def _match_rows(
 def _description_matches(
     expected: Optional[str], actual: Optional[str]
 ) -> bool:
+    """Return whether two descriptions match after normalization."""
     if not expected:
         return not actual
     if not actual:
@@ -253,6 +257,7 @@ def _description_matches(
 
 
 def _ratio(numerator: int, denominator: int) -> float:
+    """Return ``numerator / denominator``, or 1.0 when the denominator is zero."""
     return numerator / denominator if denominator else 1.0
 
 
@@ -315,6 +320,7 @@ def score_extraction(
         )
 
     def _check(expected_value: object, actual_value: object) -> Optional[bool]:
+        """Compare values, returning ``None`` when nothing is pinned."""
         if expected_value is None:
             return None
         return expected_value == actual_value

--- a/bankstatementparser/hybrid/llm_extractor.py
+++ b/bankstatementparser/hybrid/llm_extractor.py
@@ -127,6 +127,7 @@ class LLMExtractor:
         return _build_result(payload, raw, source_text=statement_text)
 
     def _resolve_completion(self) -> CompletionFn:
+        """Return the injected completion callable or import a backend."""
         if self._completion_fn is not None:
             return self._completion_fn
         # Auto-select the direct Ollama bridge for any ollama/* model
@@ -141,14 +142,14 @@ class LLMExtractor:
 
         if is_ollama_model(self.model):
             return ollama_direct_completion
-        try:  # pragma: no cover - optional dep
+        try:
             from litellm import completion
-        except ImportError as exc:  # pragma: no cover - optional dep
+        except ImportError as exc:
             raise LLMExtractorError(
                 "litellm is required for LLM extraction. "
                 "Install with: pip install bankstatementparser[hybrid]"
             ) from exc
-        return completion  # type: ignore[no-any-return]  # pragma: no cover
+        return completion  # type: ignore[no-any-return]
 
 
 def _extract_message_content(response: Any) -> str:
@@ -162,6 +163,7 @@ def _parse_json_payload(raw: str) -> dict[str, Any]:
 
 
 def _to_decimal(value: Any) -> Optional[Decimal]:
+    """Coerce a value to ``Decimal``, returning ``None`` when empty."""
     if value in (None, ""):
         return None
     try:
@@ -203,6 +205,7 @@ def _build_result(
     source_text: str = "",
     source_method: SourceMethod = "llm",
 ) -> LLMExtractionResult:
+    """Convert a parsed LLM payload into an :class:`LLMExtractionResult`."""
     raw_txs = payload.get("transactions") or []
     if not isinstance(raw_txs, list):
         raise LLMExtractorError("LLM 'transactions' field must be a list")

--- a/bankstatementparser/hybrid/ollama_direct.py
+++ b/bankstatementparser/hybrid/ollama_direct.py
@@ -91,7 +91,7 @@ def ollama_direct_completion(**kwargs: Any) -> dict[str, Any]:
     """
     try:
         import httpx
-    except ImportError as exc:  # pragma: no cover - optional dep
+    except ImportError as exc:
         raise OllamaDirectError(
             "httpx is required for the direct Ollama bridge. "
             "Install with: pip install bankstatementparser[hybrid]"

--- a/bankstatementparser/hybrid/orchestrator.py
+++ b/bankstatementparser/hybrid/orchestrator.py
@@ -109,6 +109,7 @@ class IngestResult:
         return json.dumps(self._to_dict(), indent=indent, sort_keys=False)
 
     def _to_dict(self) -> dict[str, Any]:
+        """Build the JSON-serializable dict representation."""
         return {
             "schema_version": 1,
             "source_method": self.source_method,
@@ -146,6 +147,7 @@ class IngestResult:
 
     @classmethod
     def _from_dict(cls, data: dict[str, Any]) -> IngestResult:
+        """Reconstruct an instance from a decoded JSON dict, validating fields."""
         version = data.get("schema_version")
         if version not in (None, 1):
             raise ValueError(
@@ -185,6 +187,7 @@ class IngestResult:
 def _verification_to_dict(
     verification: Optional[BalanceVerification],
 ) -> Optional[dict[str, Any]]:
+    """Serialize a :class:`BalanceVerification` to a JSON-safe dict."""
     if verification is None:
         return None
     return {
@@ -203,6 +206,7 @@ def _verification_to_dict(
 def _verification_from_dict(
     data: Any,
 ) -> Optional[BalanceVerification]:
+    """Reconstruct a :class:`BalanceVerification` from a decoded dict."""
     if data is None:
         return None
     if not isinstance(data, dict):
@@ -229,12 +233,14 @@ def _verification_from_dict(
 
 
 def _decimal_to_str(value: Optional[Decimal]) -> Optional[str]:
+    """Encode a ``Decimal`` as a plain string, preserving ``None``."""
     if value is None:
         return None
     return format(value, "f")
 
 
 def _decimal_from_str(value: Any) -> Optional[Decimal]:
+    """Decode a string back into a ``Decimal``, preserving ``None``/empty."""
     if value is None or value == "":
         return None
     return Decimal(str(value))
@@ -313,6 +319,7 @@ def smart_ingest(
 
 
 def _safe_detect(file_path: Path, warnings: list[str]) -> Optional[str]:
+    """Detect the statement format, recording a warning on no match."""
     try:
         return detect_statement_format(str(file_path))
     except Exception as exc:
@@ -337,6 +344,7 @@ def _run_deterministic(
     closing_balance: Optional[Decimal],
     warnings: list[str],
 ) -> IngestResult:
+    """Run the deterministic parser and wrap its output in an IngestResult."""
     parser = create_parser(str(file_path), fmt)
     raw = parser.parse()
     transactions = _coerce_transactions(raw, source=fmt)
@@ -452,6 +460,7 @@ def _run_vision(
     closing_balance: Optional[Decimal],
     warnings: list[str],
 ) -> IngestResult:
+    """Run the vision extractor and wrap its output in an IngestResult."""
     vision_extractor = vision_extractor or VisionExtractor()
     result = vision_extractor.extract(file_path)
     return _build_ingest_result(
@@ -471,6 +480,7 @@ def _build_ingest_result(
     closing_balance: Optional[Decimal],
     warnings: list[str],
 ) -> IngestResult:
+    """Assemble an IngestResult from an LLM result, running verification."""
     effective_opening = (
         opening_balance
         if opening_balance is not None
@@ -507,13 +517,13 @@ def _coerce_transactions(raw: object, *, source: str) -> list[Transaction]:
     if callable(to_dict):
         try:
             records = list(to_dict("records"))
-        except TypeError:  # pragma: no cover - non-DataFrame fallback
+        except TypeError:
             records = []
     elif isinstance(raw, list):
         records = [dict(item) for item in raw if isinstance(item, dict)]
     elif isinstance(raw, dict):
         records = [dict(raw)]
-    else:  # pragma: no cover - defensive
+    else:
         records = []
 
     transactions: list[Transaction] = []

--- a/bankstatementparser/hybrid/pdf_text.py
+++ b/bankstatementparser/hybrid/pdf_text.py
@@ -90,17 +90,18 @@ def extract_text_pages(
 
     if engine == "pypdf":
         pages = _extract_with_pypdf(pdf_path)
-    elif engine == "pdfplumber":  # pragma: no cover - opt-in extra
+    elif engine == "pdfplumber":
         pages = _extract_with_pdfplumber(pdf_path)
-    else:  # pragma: no cover - guarded by Literal
+    else:
         raise PDFExtractionError(f"Unknown PDF engine: {engine}")
     return [_strip_noise(page) for page in pages]
 
 
 def _extract_with_pypdf(pdf_path: Path) -> list[str]:
+    """Extract per-page text using the ``pypdf`` engine."""
     try:
         from pypdf import PdfReader
-    except ImportError as exc:  # pragma: no cover - optional dep
+    except ImportError as exc:
         raise PDFExtractionError(
             "pypdf is required for PDF extraction. "
             "Install with: pip install bankstatementparser[hybrid]"
@@ -109,7 +110,7 @@ def _extract_with_pypdf(pdf_path: Path) -> list[str]:
     try:
         reader = PdfReader(str(pdf_path))
         return [page.extract_text() or "" for page in reader.pages]
-    except Exception as exc:  # pragma: no cover - defensive
+    except Exception as exc:
         raise PDFExtractionError(
             f"Failed to read PDF {pdf_path}: {exc}"
         ) from exc
@@ -117,7 +118,8 @@ def _extract_with_pypdf(pdf_path: Path) -> list[str]:
 
 def _extract_with_pdfplumber(
     pdf_path: Path,
-) -> list[str]:  # pragma: no cover - opt-in extra
+) -> list[str]:
+    """Extract per-page text using the ``pdfplumber`` engine."""
     try:
         import pdfplumber
     except ImportError as exc:

--- a/bankstatementparser/hybrid/vision.py
+++ b/bankstatementparser/hybrid/vision.py
@@ -314,9 +314,10 @@ class VisionExtractor:
         )
 
     def _render_pages(self, pdf_path: Path) -> list[bytes]:
+        """Render each PDF page (up to :attr:`max_pages`) as a PNG."""
         try:
             import pypdfium2 as pdfium
-        except ImportError as exc:  # pragma: no cover - optional dep
+        except ImportError as exc:
             raise VisionExtractorError(
                 "pypdfium2 is required for vision extraction. "
                 "Install with: "
@@ -358,7 +359,7 @@ class VisionExtractor:
         """
         try:
             import pypdfium2 as pdfium
-        except ImportError as exc:  # pragma: no cover - optional dep
+        except ImportError as exc:
             raise VisionExtractorError(
                 "pypdfium2 is required for vision extraction. "
                 "Install with: "
@@ -407,6 +408,7 @@ class VisionExtractor:
         return all_strips
 
     def _resolve_completion(self) -> CompletionFn:
+        """Return the injected completion callable or import a backend."""
         if self._completion_fn is not None:
             return self._completion_fn
         # Auto-select the direct Ollama bridge for any ollama/* model
@@ -421,15 +423,15 @@ class VisionExtractor:
 
         if is_ollama_model(self.model):
             return ollama_direct_completion
-        try:  # pragma: no cover - optional dep
+        try:
             from litellm import completion
-        except ImportError as exc:  # pragma: no cover - optional dep
+        except ImportError as exc:
             raise VisionExtractorError(
                 "litellm is required for vision extraction. "
                 "Install with: "
                 "pip install bankstatementparser[hybrid-vision]"
             ) from exc
-        return completion  # type: ignore[no-any-return]  # pragma: no cover
+        return completion  # type: ignore[no-any-return]
 
 
 STRIP_HEADER_SYSTEM_PROMPT = """You are a meticulous Financial Data

--- a/bankstatementparser/parallel.py
+++ b/bankstatementparser/parallel.py
@@ -110,7 +110,7 @@ def parse_files_parallel(
             path = future_to_path[future]
             try:
                 results[path] = future.result()
-            except Exception as exc:  # pragma: no cover
+            except Exception as exc:
                 results[path] = FileResult(
                     path=path,
                     status="FAILED",

--- a/bankstatementparser/transaction_deduplicator.py
+++ b/bankstatementparser/transaction_deduplicator.py
@@ -31,12 +31,14 @@ from .transaction_models import Transaction
 
 
 def _days_between(left: date | None, right: date | None) -> int | None:
+    """Return the absolute day gap between two dates, or None."""
     if left is None or right is None:
         return None
     return abs((left - right).days)
 
 
 def _description_similarity(left: Transaction, right: Transaction) -> float:
+    """Return the 0.0-1.0 similarity of two normalized descriptions."""
     if not left.normalized_description or not right.normalized_description:
         return 0.0
     return SequenceMatcher(
@@ -76,6 +78,8 @@ class DeduplicationResult(BaseModel):
 
 @dataclass(frozen=True)
 class _Candidate:
+    """A transaction paired with its source index and primary hash."""
+
     index: int
     transaction: Transaction
     primary_hash: str
@@ -247,6 +251,7 @@ class Deduplicator:
     def _candidate_groups_by_primary(
         self, candidates: list[_Candidate]
     ) -> dict[str, list[_Candidate]]:
+        """Group candidates by their primary hash."""
         groups: dict[str, list[_Candidate]] = defaultdict(list)
         for candidate in candidates:
             groups[candidate.primary_hash].append(candidate)
@@ -255,6 +260,7 @@ class Deduplicator:
     def _find_exact_duplicates(
         self, candidates: list[_Candidate]
     ) -> list[ExactDuplicateGroup]:
+        """Return groups of candidates sharing a primary hash."""
         groups = self._candidate_groups_by_primary(candidates)
         exact_groups = []
         for primary_hash, bucket in sorted(groups.items()):
@@ -281,6 +287,7 @@ class Deduplicator:
         *,
         excluded_indices: set[int],
     ) -> tuple[list[MatchGroup], set[int]]:
+        """Find probable and temporal match groups for operator review."""
         probable_groups, probable_indices = self._find_probable_matches(
             candidates
         )
@@ -299,6 +306,7 @@ class Deduplicator:
     def _find_probable_matches(
         self, candidates: list[_Candidate]
     ) -> tuple[list[MatchGroup], set[int]]:
+        """Match candidates by hash collision and description similarity."""
         groups = []
         matched_indices: set[int] = set()
         for bucket in self._candidate_groups_by_primary(candidates).values():
@@ -343,6 +351,7 @@ class Deduplicator:
     def _find_temporal_matches(
         self, candidates: list[_Candidate]
     ) -> tuple[list[MatchGroup], set[int]]:
+        """Match candidates with equal amounts but shifted value dates."""
         buckets: dict[tuple[str, str, str], list[_Candidate]] = defaultdict(
             list
         )
@@ -363,6 +372,7 @@ class Deduplicator:
             component: list[_Candidate],
             similarities: list[float],
         ) -> None:
+            """Record a matched component as a temporal match group."""
             matched_indices.update(candidate.index for candidate in component)
             groups.append(self._temporal_group(component, similarities))
 
@@ -413,6 +423,7 @@ class Deduplicator:
         component: list[_Candidate],
         similarities: list[float],
     ) -> MatchGroup:
+        """Build a temporal MatchGroup with a confidence and reason."""
         max_delta = (
             _days_between(
                 component[0].transaction.value_date,

--- a/bankstatementparser/transaction_models.py
+++ b/bankstatementparser/transaction_models.py
@@ -34,6 +34,7 @@ from pydantic import (
 
 
 def _coerce_decimal(value: object) -> Decimal:
+    """Coerce a value into a Decimal amount, raising if empty."""
     text = str(value).strip()
     if not text:
         raise ValueError("amount is required")
@@ -41,6 +42,7 @@ def _coerce_decimal(value: object) -> Decimal:
 
 
 def _parse_date(value: object) -> date | None:
+    """Parse a value into a date across common formats, or None."""
     if value in (None, ""):
         return None
     if isinstance(value, date) and not isinstance(value, datetime):
@@ -98,6 +100,7 @@ def normalize_description(value: str | None) -> str:
 
 
 def _first_value(record: Mapping[str, object], *keys: str) -> object | None:
+    """Return the first non-empty value among the given keys, or None."""
     for key in keys:
         if key in record and record[key] not in (None, ""):
             return record[key]
@@ -136,6 +139,7 @@ class BoundingBox(BaseModel):
 
     @model_validator(mode="after")
     def _check_non_inverted(self) -> BoundingBox:
+        """Validate that the box corners are not inverted."""
         if self.x0 > self.x1:
             raise ValueError(
                 f"BoundingBox x0 ({self.x0}) must be <= x1 ({self.x1})"

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,10 +51,11 @@ prerequisites table, Mermaid flow diagram, and cross-platform runbook.
 | `hybrid/01_smart_ingest_deterministic.py` | Path A — `smart_ingest()` against a CAMT.053 file ($0, no LLM) |
 | `hybrid/02_smart_ingest_text_llm.py` | Path B — text-LLM extraction from a digital PDF (mock or live Ollama) |
 | `hybrid/03_smart_ingest_vision.py` | Path C — multimodal vision extraction from a scanned PDF, with `LOW_TEXT_DENSITY` auto-routing |
-| `hybrid/04_golden_rule.py` | All three `verify_balance()` outcomes: `VERIFIED`, `DISCREPANCY`, `FAILED` |
+| `hybrid/04_golden_rule.py` | `verify_balance()`, `verify_transactions()`, and `verify_continuity()` across the `VERIFIED`, `DISCREPANCY`, and `UNVERIFIABLE` outcomes |
 | `hybrid/05_dedupe_recurring.py` | `normalize_description()` noise stripping + `dedupe_by_hash()` idempotent batching |
 | `hybrid/06_cli_walkthrough.sh` | Four flavours of the new `--type ingest` CLI subcommand (bash) |
 | `hybrid/06_cli_walkthrough.ps1` | PowerShell sibling for native Windows (no WSL required) |
+| `hybrid/07_scan_and_ingest.py` | Bulk directory ingest with `scan_and_ingest()` — cross-file hash dedup + continuity check |
 
 ## ZIP Security
 

--- a/examples/compatibility_wrappers.py
+++ b/examples/compatibility_wrappers.py
@@ -21,6 +21,7 @@ from common import CAMT_FIXTURE, PAIN001_FIXTURE
 
 
 def main() -> None:
+    """Demonstrate the backward-compatible parser class wrappers."""
     camt = Camt053Parser(str(CAMT_FIXTURE), redact_pii=True)
     pain = Pain001Parser(str(PAIN001_FIXTURE), redact_pii=True)
 

--- a/examples/export_camt.py
+++ b/examples/export_camt.py
@@ -18,6 +18,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Export a CAMT fixture to the supported output formats."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-dir", default="example-output/camt")
     args = parser.parse_args()

--- a/examples/export_camt_excel.py
+++ b/examples/export_camt_excel.py
@@ -18,6 +18,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Export a CAMT fixture to an Excel workbook."""
     parser = CamtParser(str(CAMT_FIXTURE))
     output = Path(tempfile.gettempdir()) / "camt_export.xlsx"
     parser.camt_to_excel(str(output))

--- a/examples/export_pain001.py
+++ b/examples/export_pain001.py
@@ -18,6 +18,7 @@ from common import PAIN001_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Export a pain.001 fixture to the supported output formats."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-dir", default="example-output/pain001")
     args = parser.parse_args()

--- a/examples/hybrid/01_smart_ingest_deterministic.py
+++ b/examples/hybrid/01_smart_ingest_deterministic.py
@@ -34,6 +34,7 @@ CAMT_FIXTURE = REPO_ROOT / "tests" / "test_data" / "camt.053.001.02.xml"
 
 
 def main() -> int:
+    """Run smart ingest over a structured CAMT fixture."""
     if not CAMT_FIXTURE.exists():
         print(f"Fixture not found: {CAMT_FIXTURE}", file=sys.stderr)
         return 1

--- a/examples/hybrid/02_smart_ingest_text_llm.py
+++ b/examples/hybrid/02_smart_ingest_text_llm.py
@@ -153,6 +153,7 @@ def _mock_completion(**kwargs: Any) -> dict[str, Any]:
 
 
 def main() -> int:
+    """Route a text-based PDF through the text-LLM extraction path."""
     if not SAMPLE_PDF.exists():
         print(
             "Sample PDF not found. Run first:\n"

--- a/examples/hybrid/03_smart_ingest_vision.py
+++ b/examples/hybrid/03_smart_ingest_vision.py
@@ -104,6 +104,7 @@ def _mock_vision_completion(**kwargs: Any) -> dict[str, Any]:
 
 
 def main() -> int:
+    """Route a scanned PDF through the vision extraction path."""
     if not SAMPLE_PDF.exists():
         print(
             "Sample scan not found. Run first:\n"
@@ -209,18 +210,30 @@ def _install_fake_pdfium() -> None:
     fake = types.ModuleType("pypdfium2")
 
     class _Bitmap:
+        """Stand-in for a rendered pypdfium2 bitmap."""
+
         def to_pil(self) -> Any:
+            """Return a minimal PIL-like image object."""
+
             class _PilLike:
+                """Stand-in for a PIL image exposing only ``save``."""
+
                 def save(self, buffer: Any, format: str) -> None:
+                    """Write placeholder PNG bytes to the buffer."""
                     buffer.write(b"PNG_BYTES")
 
             return _PilLike()
 
     class _Page:
+        """Stand-in for a pypdfium2 page."""
+
         def render(self, scale: float) -> _Bitmap:
+            """Return a fake rendered bitmap for the page."""
             return _Bitmap()
 
     class _PdfDocument:
+        """Stand-in for a single-page pypdfium2 document."""
+
         def __init__(self, _path: str) -> None:
             pass
 

--- a/examples/hybrid/04_golden_rule.py
+++ b/examples/hybrid/04_golden_rule.py
@@ -33,10 +33,13 @@ from bankstatementparser import Transaction  # noqa: E402
 from bankstatementparser.hybrid import (  # noqa: E402
     VerificationStatus,
     verify_balance,
+    verify_continuity,
+    verify_transactions,
 )
 
 
 def _row(amount: str, day: str, desc: str) -> Transaction:
+    """Build a Transaction from string amount, date, and description."""
     return Transaction(
         amount=Decimal(amount),
         booking_date=day,  # type: ignore[arg-type]
@@ -64,6 +67,7 @@ DROPPED_ROW: list[Transaction] = [
 
 
 def _print(label: str, result: object) -> None:
+    """Print a labelled summary of a balance verification result."""
     print(f"-- {label}")
     print(f"   status:         {result.status.value.upper()}")  # type: ignore[attr-defined]
     print(f"   total credits:  {result.total_credits}")  # type: ignore[attr-defined]
@@ -76,6 +80,7 @@ def _print(label: str, result: object) -> None:
 
 
 def _expect(actual: VerificationStatus, expected: VerificationStatus) -> None:
+    """Raise SystemExit if the actual status differs from expected."""
     if actual is not expected:
         raise SystemExit(
             f"Example contract violated: expected {expected.value}, "
@@ -84,6 +89,7 @@ def _expect(actual: VerificationStatus, expected: VerificationStatus) -> None:
 
 
 def main() -> int:
+    """Demonstrate balance verification across integrity scenarios."""
     print("Scenario 1: clean statement, all transactions captured")
     print()
     result = verify_balance(
@@ -120,7 +126,54 @@ def main() -> int:
     print("     or skip integrity check entirely (LLMs sometimes miss them).")
     print()
 
-    print("All three scenarios behave as expected.")
+    print("Scenario 4: currency-aware Golden Rule (verify_transactions)")
+    print()
+    # verify_transactions delegates to verify_balance for a single
+    # currency, and checks each currency independently when a statement
+    # mixes them — so a multi-currency statement never reports a false
+    # discrepancy from summing GBP and EUR together.
+    result = verify_transactions(
+        HAPPY_PATH,
+        opening_balance=Decimal("1500.00"),
+        closing_balance=Decimal("2676.66"),
+    )
+    _print("VERIFIED expected", result)
+    _expect(result.status, VerificationStatus.VERIFIED)
+
+    print("Scenario 5: cross-statement continuity (verify_continuity)")
+    print()
+    # The closing balance of each statement must equal the opening
+    # balance of the next. A clean chain verifies; a hallucinated or
+    # missing balance shows up as a continuity break.
+    chained = verify_continuity(
+        [
+            ("2026-02", Decimal("1000.00"), Decimal("1500.00")),
+            ("2026-03", Decimal("1500.00"), Decimal("2100.00")),
+            ("2026-04", Decimal("2100.00"), Decimal("2676.66")),
+        ]
+    )
+    print(f"   status:         {chained.status.value.upper()}")
+    print(f"   checked links:  {chained.checked_links}")
+    print(f"   message:        {chained.message}")
+    print()
+    _expect(chained.status, VerificationStatus.VERIFIED)
+
+    broken = verify_continuity(
+        [
+            ("2026-02", Decimal("1000.00"), Decimal("1500.00")),
+            # Gap: previous closed at 1500 but this opens at 1600.
+            ("2026-03", Decimal("1600.00"), Decimal("2100.00")),
+        ]
+    )
+    print(f"   broken chain status: {broken.status.value.upper()}")
+    print(f"   breaks:              {len(broken.breaks)}")
+    print()
+    _expect(broken.status, VerificationStatus.DISCREPANCY)
+    print("  -> Action: a missing month or hallucinated balance breaks")
+    print("     the chain — flag the batch for a human to reconcile.")
+    print()
+
+    print("All five scenarios behave as expected.")
     return 0
 
 

--- a/examples/hybrid/05_dedupe_recurring.py
+++ b/examples/hybrid/05_dedupe_recurring.py
@@ -49,6 +49,7 @@ from bankstatementparser.transaction_models import (  # noqa: E402
 
 
 def _tx(amount: str, day: str, raw_desc: str) -> Transaction:
+    """Build a Transaction with a normalized description."""
     return Transaction(
         amount=Decimal(amount),
         booking_date=day,  # type: ignore[arg-type]
@@ -58,6 +59,7 @@ def _tx(amount: str, day: str, raw_desc: str) -> Transaction:
 
 
 def main() -> int:
+    """Demonstrate description normalization and recurring dedupe."""
     print("=" * 64)
     print("PART 1 — normalize_description() strips noise")
     print("=" * 64)

--- a/examples/hybrid/07_scan_and_ingest.py
+++ b/examples/hybrid/07_scan_and_ingest.py
@@ -1,0 +1,81 @@
+"""
+Example 07 — Bulk directory ingest with `scan_and_ingest()`.
+
+`smart_ingest()` handles one file; `scan_and_ingest()` walks a whole
+directory, runs `smart_ingest()` on every match, deduplicates
+transactions across files by `transaction_hash`, and (when two or more
+statements are ingested) runs a cross-statement continuity check so a
+missing month or a duplicated export surfaces immediately.
+
+This is the batch-treasury workflow: point it at a folder of monthly
+statements and get back one clean, de-duplicated transaction set plus
+an integrity verdict.
+
+Run from the repository root:
+
+    python examples/hybrid/07_scan_and_ingest.py
+
+Cross-platform: pure Python, no optional extras required — this script
+copies the bundled CAMT fixture into a temporary directory so it is
+fully self-contained and deterministic.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from bankstatementparser.hybrid import scan_and_ingest  # noqa: E402
+
+CAMT_FIXTURE = REPO_ROOT / "tests" / "test_data" / "camt.053.001.02.xml"
+
+
+def main() -> int:
+    """Run scan_and_ingest over a temporary folder of statements."""
+    if not CAMT_FIXTURE.exists():
+        print(f"Fixture not found: {CAMT_FIXTURE}", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory() as raw_dir:
+        directory = Path(raw_dir)
+        # Two copies of the same statement: a realistic "I exported the
+        # same month twice" mistake. The cross-file hash dedup collapses
+        # the duplicate rows back into a single clean set.
+        shutil.copy(CAMT_FIXTURE, directory / "january.xml")
+        shutil.copy(CAMT_FIXTURE, directory / "january-again.xml")
+
+        print(f"Scanning: {directory}")
+        print()
+        print("Calling scan_and_ingest()...")
+        print()
+
+        result = scan_and_ingest(directory, extensions={".xml"})
+
+        print(f"  Files ingested:        {result.file_count}")
+        print(f"  Unique transactions:   {result.total_unique}")
+        print(f"  Duplicate rows skipped: {result.total_skipped}")
+        print(f"  Failures:              {result.failure_count}")
+        if result.continuity is not None:
+            print(
+                f"  Continuity status:     "
+                f"{result.continuity.status.value.upper()}"
+            )
+        print()
+
+    print(
+        "scan_and_ingest() deduplicated the re-exported month by "
+        "transaction_hash,"
+    )
+    print("so each booking appears exactly once in unique_transactions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/hybrid/README.md
+++ b/examples/hybrid/README.md
@@ -97,6 +97,7 @@ python examples/hybrid/03_smart_ingest_vision.py       # mock mode
 python examples/hybrid/04_golden_rule.py
 python examples/hybrid/05_dedupe_recurring.py
 bash   examples/hybrid/06_cli_walkthrough.sh
+python examples/hybrid/07_scan_and_ingest.py
 ```
 
 The text-LLM and vision examples both default to **mock mode** so
@@ -111,10 +112,11 @@ above to switch to the live path.
 | [`01_smart_ingest_deterministic.py`](01_smart_ingest_deterministic.py) | A | nothing | `smart_ingest()` against a CAMT.053 fixture, `source_method='deterministic'`, `transaction_hash` per row, $0 cost |
 | [`02_smart_ingest_text_llm.py`](02_smart_ingest_text_llm.py) | B | `BSP_HYBRID_MODEL` | Digital PDF → `pypdf` text → LiteLLM → `Transaction` rows. Mock mode shipped for offline runs. |
 | [`03_smart_ingest_vision.py`](03_smart_ingest_vision.py) | C | `BSP_HYBRID_VISION_MODEL` | Scan → `pypdfium2` render → multimodal LLM → rows. Demonstrates `LOW_TEXT_DENSITY_THRESHOLD` automatic handover and a `DISCREPANCY` outcome. |
-| [`04_golden_rule.py`](04_golden_rule.py) | n/a | nothing | All three `verify_balance()` outcomes (`VERIFIED`, `DISCREPANCY`, `FAILED`) on the same dataset. |
+| [`04_golden_rule.py`](04_golden_rule.py) | n/a | nothing | `verify_balance()`, `verify_transactions()`, and `verify_continuity()` across the `VERIFIED`, `DISCREPANCY`, and `UNVERIFIABLE` outcomes on the same dataset. |
 | [`05_dedupe_recurring.py`](05_dedupe_recurring.py) | n/a | nothing | `normalize_description()` noise stripping, `transaction_hash` stability, idempotent batching with `Deduplicator.dedupe_by_hash()`. |
 | [`06_cli_walkthrough.sh`](06_cli_walkthrough.sh) | A/B/C | `BSP_HYBRID_*` env vars | Four flavours of the new `--type ingest` CLI subcommand (bash, for macOS / Linux / WSL). |
 | [`06_cli_walkthrough.ps1`](06_cli_walkthrough.ps1) | A/B/C | `BSP_HYBRID_*` env vars | PowerShell sibling of the bash walkthrough — runs identically on native Windows (PowerShell 7+) without WSL. |
+| [`07_scan_and_ingest.py`](07_scan_and_ingest.py) | A | nothing | `scan_and_ingest()` over a directory of statements: cross-file `transaction_hash` dedup, `ScanResult` summary, and the cross-statement `verify_continuity()` check. |
 
 ## Mock vs. live mode — what to expect
 

--- a/examples/hybrid/generate_sample_pdfs.py
+++ b/examples/hybrid/generate_sample_pdfs.py
@@ -57,6 +57,7 @@ TRANSACTIONS: list[tuple[str, str, Decimal]] = [
 
 
 def closing_balance() -> Decimal:
+    """Return the closing balance derived from the sample transactions."""
     return OPENING_BALANCE + sum(
         (amount for _date, _desc, amount in TRANSACTIONS),
         Decimal("0"),
@@ -64,6 +65,7 @@ def closing_balance() -> Decimal:
 
 
 def _try_import_reportlab() -> object:
+    """Import reportlab helpers or exit with an install hint."""
     try:
         from reportlab.lib.pagesizes import A4
         from reportlab.lib.units import mm
@@ -78,6 +80,7 @@ def _try_import_reportlab() -> object:
 
 
 def _try_import_pypdfium2() -> object:
+    """Import pypdfium2 or exit with an install hint."""
     try:
         import pypdfium2 as pdfium
 
@@ -90,6 +93,7 @@ def _try_import_pypdfium2() -> object:
 
 
 def _try_import_pil() -> object:
+    """Import Pillow's Image or exit with an install hint."""
     try:
         from PIL import Image
 
@@ -187,6 +191,7 @@ def render_scanned_pdf(source: Path, target: Path) -> None:
 
 
 def main() -> None:
+    """Generate the digital and scanned sample PDFs."""
     print(f"Output directory: {OUTPUT_DIR}")
     print()
     print("=" * 60)

--- a/examples/inspect_camt.py
+++ b/examples/inspect_camt.py
@@ -17,6 +17,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Inspect balances, transactions, and summary stats of a CAMT file."""
     parser = CamtParser(str(CAMT_FIXTURE))
 
     balances = parser.get_account_balances()

--- a/examples/parse_camt_basic.py
+++ b/examples/parse_camt_basic.py
@@ -17,6 +17,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Parse a CAMT fixture and print a preview of the transactions."""
     parser = CamtParser(str(CAMT_FIXTURE))
     transactions = parser.parse()
 

--- a/examples/parse_camt_from_string.py
+++ b/examples/parse_camt_from_string.py
@@ -17,6 +17,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Parse CAMT XML supplied as an in-memory string."""
     xml_text = CAMT_FIXTURE.read_text(encoding="utf-8")
     parser = CamtParser.from_string(xml_text)
     transactions = parser.parse()

--- a/examples/parse_detected_formats.py
+++ b/examples/parse_detected_formats.py
@@ -13,6 +13,7 @@ if str(ROOT) not in sys.path:
 
 
 def main() -> None:
+    """Detect statement formats and parse each sample accordingly."""
     from bankstatementparser import (
         create_parser,
         detect_statement_format,

--- a/examples/parse_pain001_basic.py
+++ b/examples/parse_pain001_basic.py
@@ -17,6 +17,7 @@ from common import PAIN001_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Parse a pain.001 fixture and print a preview of the payments."""
     parser = Pain001Parser(str(PAIN001_FIXTURE))
     payments = parser.parse()
 

--- a/examples/stream_camt.py
+++ b/examples/stream_camt.py
@@ -18,6 +18,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Stream the first few transactions from a CAMT fixture."""
     parser = CamtParser(str(CAMT_FIXTURE))
 
     for index, transaction in enumerate(

--- a/examples/stream_pain001.py
+++ b/examples/stream_pain001.py
@@ -18,6 +18,7 @@ from common import PAIN001_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Stream the first few payments from a pain.001 fixture."""
     parser = Pain001Parser(str(PAIN001_FIXTURE))
 
     for index, payment in enumerate(

--- a/examples/validate_input.py
+++ b/examples/validate_input.py
@@ -20,6 +20,7 @@ from common import CAMT_FIXTURE  # noqa: E402
 
 
 def main() -> None:
+    """Validate a legitimate file path and reject a dangerous one."""
     validator = InputValidator()
 
     # Validate a legitimate file

--- a/poetry.lock
+++ b/poetry.lock
@@ -280,14 +280,14 @@ files = [
 name = "attrs"
 version = "26.1.0"
 description = "Classes Without Boilerplate"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "python_version < \"3.14\" and (extra == \"hybrid\" or extra == \"hybrid-plus\" or extra == \"hybrid-vision\" or extra == \"enrichment\")"
+groups = ["main", "dev"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
 ]
+markers = {main = "python_version < \"3.14\" and (extra == \"hybrid\" or extra == \"hybrid-plus\" or extra == \"hybrid-vision\" or extra == \"enrichment\")"}
 
 [[package]]
 name = "babel"
@@ -605,7 +605,7 @@ version = "8.4.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
     {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
@@ -626,7 +626,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" and (extra == \"api\" or python_version < \"3.14\") and (extra == \"hybrid\" or extra == \"hybrid-plus\" or extra == \"hybrid-vision\" or extra == \"enrichment\" or extra == \"api\")", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "platform_system == \"Windows\" and (extra == \"api\" or python_version < \"3.14\") and (extra == \"hybrid\" or extra == \"hybrid-plus\" or extra == \"hybrid-vision\" or extra == \"enrichment\" or extra == \"api\")"}
 
 [[package]]
 name = "coverage"
@@ -1441,6 +1441,32 @@ files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
+
+[[package]]
+name = "interrogate"
+version = "1.7.0"
+description = "Interrogate a codebase for docstring coverage."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "interrogate-1.7.0-py3-none-any.whl", hash = "sha256:b13ff4dd8403369670e2efe684066de9fcb868ad9d7f2b4095d8112142dc9d12"},
+    {file = "interrogate-1.7.0.tar.gz", hash = "sha256:a320d6ec644dfd887cc58247a345054fc4d9f981100c45184470068f4b3719b0"},
+]
+
+[package.dependencies]
+attrs = "*"
+click = ">=7.1"
+colorama = "*"
+py = "*"
+tabulate = "*"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["cairosvg", "coverage[toml]", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "sphinx", "sphinx-autobuild", "wheel"]
+docs = ["sphinx", "sphinx-autobuild"]
+png = ["cairosvg"]
+tests = ["coverage[toml]", "pytest", "pytest-cov", "pytest-mock"]
 
 [[package]]
 name = "jinja2"
@@ -3185,6 +3211,18 @@ files = [
 ]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["dev"]
+files = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 description = "Get CPU info with pure Python"
@@ -4228,6 +4266,21 @@ files = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3"},
+    {file = "tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "tiktoken"
 version = "0.13.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
@@ -4714,4 +4767,4 @@ polars = ["polars"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "d0252352c4f3536c493b7e04ac4a40fb1df10af7f2021fed7b15555401d07a08"
+content-hash = "3b45d0536a6817b2144efd4f224438a00e05c2c26be62f47c91dd88cc9e10c4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ruff = "^0.15.7"
 mypy = ">=1.5,<3"
 bandit = "^1.7.0"
 hypothesis = ">=6.82,<7"
+interrogate = "^1.7.0"
 
 [tool.poetry.group.docs]
 optional = true
@@ -162,6 +163,28 @@ markers = [
     "slow: marks tests as slow-running performance or regression checks",
 ]
 
+[tool.interrogate]
+# Documentation coverage is enforced at 100% across the package, the
+# developer/CI helper scripts, and the runnable examples. Test modules
+# and the local virtualenv are excluded; everything else — including
+# private and nested helpers — must carry a docstring.
+fail-under = 100
+ignore-init-method = true
+ignore-magic = true
+ignore-module = false
+ignore-private = false
+ignore-nested-functions = false
+ignore-semiprivate = false
+exclude = [
+    ".venv",
+    "build",
+    "dist",
+    "tests",
+    "setup.py",
+    "docs",
+]
+verbose = 1
+
 [tool.coverage.run]
 source = ["bankstatementparser"]
 branch = true
@@ -170,5 +193,4 @@ branch = true
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
-    "raise NotImplementedError",
 ]

--- a/scripts/generate_checksums.py
+++ b/scripts/generate_checksums.py
@@ -10,12 +10,14 @@ from pathlib import Path
 
 
 def iter_files(directory: Path) -> Iterable[Path]:
+    """Yield the regular files in a directory in sorted order."""
     for path in sorted(directory.iterdir()):
         if path.is_file():
             yield path
 
 
 def file_checksum(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file, read in chunks."""
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
@@ -24,6 +26,7 @@ def file_checksum(path: Path) -> str:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the checksum generator."""
     parser = argparse.ArgumentParser(
         description="Generate SHA-256 checksums for all files in a directory."
     )
@@ -42,6 +45,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    """Write SHA-256 checksums for a directory's files to an output file."""
     args = parse_args()
     output_path = args.output or (args.directory / "SHA256SUMS")
     output_lines = []

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -21,15 +21,18 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def load_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file and return its contents as a dictionary."""
     with path.open("rb") as handle:
         return cast(dict[str, Any], tomllib.load(handle))
 
 
 def normalize_distribution_name(name: str) -> str:
+    """Normalize a distribution name to lowercase with hyphens."""
     return name.replace("_", "-").lower()
 
 
 def resolve_license(package_name: str) -> str:
+    """Return the license for an installed package, or "UNKNOWN"."""
     normalized = normalize_distribution_name(package_name)
     try:
         metadata = importlib.metadata.metadata(normalized)
@@ -51,11 +54,13 @@ def resolve_license(package_name: str) -> str:
 
 
 def package_ref(name: str, version: str) -> str:
+    """Build a PyPI package URL (purl) reference for a package."""
     normalized = quote(normalize_distribution_name(name), safe="")
     return f"pkg:pypi/{normalized}@{version}"
 
 
 def cyclonedx_component(package: dict[str, Any]) -> dict[str, Any]:
+    """Build a CycloneDX component entry from a lock package."""
     name = package["name"]
     version = package["version"]
     hashes = []
@@ -97,6 +102,7 @@ def cyclonedx_component(package: dict[str, Any]) -> dict[str, Any]:
 def build_dependency_edges(
     packages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Build CycloneDX dependency edges between locked packages."""
     available_refs = {
         normalize_distribution_name(package["name"]): package_ref(
             package["name"], package["version"]
@@ -125,6 +131,7 @@ def build_sbom(
     pyproject: dict[str, Any],
     lock_data: dict[str, Any],
 ) -> dict[str, Any]:
+    """Assemble a CycloneDX SBOM from pyproject and lock data."""
     poetry = pyproject["tool"]["poetry"]
     packages = lock_data.get("package", [])
     components = [cyclonedx_component(package) for package in packages]
@@ -175,6 +182,7 @@ def write_markdown_report(
     packages: list[dict[str, Any]],
     output_path: Path,
 ) -> None:
+    """Write a Markdown dependency report for the locked packages."""
     lines = [
         "# Dependency Report",
         "",
@@ -200,6 +208,7 @@ def write_markdown_report(
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the SBOM generator."""
     parser = argparse.ArgumentParser(
         description="Generate a CycloneDX-style SBOM and dependency report."
     )
@@ -219,6 +228,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    """Generate the SBOM JSON and Markdown dependency report files."""
     args = parse_args()
     pyproject = load_toml(ROOT / "pyproject.toml")
     lock_data = load_toml(ROOT / "poetry.lock")

--- a/scripts/run_llm_eval.py
+++ b/scripts/run_llm_eval.py
@@ -85,12 +85,14 @@ def _mock_completion_for(case: EvalCase) -> Any:
     }
 
     def completion(**_kwargs: Any) -> dict[str, Any]:
+        """Return the case's perfect answer as a completion response."""
         return {"choices": [{"message": {"content": json.dumps(payload)}}]}
 
     return completion
 
 
 def _run_case(case: EvalCase, *, args: argparse.Namespace) -> EvalScore:
+    """Extract and score a single eval case using the configured model."""
     if args.mock:
         extractor = LLMExtractor(completion_fn=_mock_completion_for(case))
     else:
@@ -107,12 +109,14 @@ def _run_case(case: EvalCase, *, args: argparse.Namespace) -> EvalScore:
 
 
 def _flag(value: bool | None) -> str:
+    """Render a tri-state correctness flag for printing."""
     if value is None:
         return "-"
     return "ok" if value else "WRONG"
 
 
 def _print_score(score: EvalScore) -> None:
+    """Print the per-case score breakdown to stdout."""
     print(f"\n=== {score.case_name} ===")
     print(
         f"  rows: {score.matched}/{score.expected_count} matched "
@@ -135,6 +139,7 @@ def _print_score(score: EvalScore) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the eval across all cases and report a pass/fail summary."""
     parser = argparse.ArgumentParser(
         description="LLM extraction accuracy eval"
     )

--- a/scripts/verify_github_commit_signatures.py
+++ b/scripts/verify_github_commit_signatures.py
@@ -20,6 +20,7 @@ NULL_SHA = "0" * 40
 
 
 def github_get_json(url: str, token: str) -> dict[str, Any]:
+    """Fetch and decode JSON from an authenticated GitHub API URL."""
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.netloc != "api.github.com":
         raise RuntimeError(
@@ -49,6 +50,7 @@ def compare_commits(
     head: str,
     token: str,
 ) -> list[dict[str, Any]]:
+    """Return the commits between two refs via the compare API."""
     compare = github_get_json(
         f"{API_ROOT}/repos/{repo}/compare/{base}...{head}",
         token,
@@ -68,6 +70,7 @@ def commits_for_initial_push(
     event: dict[str, Any],
     token: str,
 ) -> list[dict[str, Any]]:
+    """Return the commits introduced by an initial branch push."""
     commits = []
     for commit in cast(list[dict[str, Any]], event.get("commits", [])):
         sha = commit.get("id")
@@ -90,6 +93,7 @@ def commit_range_from_event(
     event_name: str,
     event: dict[str, Any],
 ) -> tuple[str, str]:
+    """Return the base and head SHAs for a GitHub event."""
     if event_name == "pull_request":
         pull_request = event["pull_request"]
         return pull_request["base"]["sha"], pull_request["head"]["sha"]
@@ -107,6 +111,7 @@ def commits_from_event(
     event: dict[str, Any],
     token: str,
 ) -> list[dict[str, Any]]:
+    """Return the commits to verify for the current GitHub event."""
     if event_name == "push" and event.get("before") == NULL_SHA:
         return commits_for_initial_push(repo, event, token)
 
@@ -115,6 +120,7 @@ def commits_from_event(
 
 
 def verify_commits(commits: Iterable[dict[str, Any]]) -> list[str]:
+    """Return failure messages for unsigned or unverified commits."""
     failures = []
     for commit in commits:
         verification = commit.get("commit", {}).get("verification", {})
@@ -128,6 +134,7 @@ def verify_commits(commits: Iterable[dict[str, Any]]) -> list[str]:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the signature verifier."""
     parser = argparse.ArgumentParser(
         description="Verify that all commits in the current GitHub event are signed."
     )
@@ -147,6 +154,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    """Verify commit signatures for the event and exit non-zero on failure."""
     args = parse_args()
     if not args.repo or not args.token:
         print(

--- a/scripts/verify_locked_hashes.py
+++ b/scripts/verify_locked_hashes.py
@@ -16,11 +16,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def load_lockfile() -> dict[str, Any]:
+    """Parse the repository's poetry.lock file into a dictionary."""
     with (ROOT / "poetry.lock").open("rb") as handle:
         return cast(dict[str, Any], tomllib.load(handle))
 
 
 def verify_packages(packages: list[dict[str, Any]]) -> list[str]:
+    """Return failure messages for packages lacking SHA-256 file hashes."""
     failures = []
     for package in packages:
         package_id = f"{package['name']}=={package['version']}"
@@ -38,6 +40,7 @@ def verify_packages(packages: list[dict[str, Any]]) -> list[str]:
 
 
 def main() -> int:
+    """Verify locked package hashes and exit non-zero on any failure."""
     packages = load_lockfile().get("package", [])
     failures = verify_packages(packages)
     if failures:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,6 +121,30 @@ def test_main_raises_without_uvicorn(
         main()
 
 
+def test_main_starts_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main`` builds the app and hands it to ``uvicorn.run``."""
+    _install_fake_fastapi(monkeypatch)
+
+    captured: dict[str, Any] = {}
+    fake_uvicorn = types.ModuleType("uvicorn")
+
+    def _run(app: Any, host: str, port: int) -> None:
+        captured.update(app=app, host=host, port=port)
+
+    fake_uvicorn.run = _run  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(
+        sys, "argv", ["bankstatementparser-api", "--port", "9999"]
+    )
+
+    main()
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 9999
+    assert captured["app"] is not None
+
+
 def test_result_to_dict_structure() -> None:
     from bankstatementparser.api import _result_to_dict
 
@@ -154,8 +178,8 @@ def test_result_to_dict_structure() -> None:
 # ---------------------------------------------------------------------------
 # Safety floor (C-1): upload size cap, suffix allow-list, basename strip,
 # generic error responses. These tests cover the helpers directly; the
-# async ``ingest`` endpoint itself is exercised by the asgi smoke tests
-# below.
+# async ``ingest`` endpoint itself is exercised by the route-level tests
+# at the end of this module.
 # ---------------------------------------------------------------------------
 
 
@@ -267,3 +291,112 @@ def test_result_to_dict_none_verification() -> None:
 
     result = _result_to_dict(_MockResult())
     assert result["verification"] is None
+
+
+# ---------------------------------------------------------------------------
+# The async ``/ingest`` endpoint, driven directly through the captured route
+# function (the fake FastAPI app exposes it via ``app._routes``). These cover
+# the bad-extension, oversize, success, and failure branches without a live
+# ASGI server.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUpload:
+    """Minimal stand-in for FastAPI's ``UploadFile``."""
+
+    def __init__(self, filename: str | None, data: bytes) -> None:
+        """Store the filename and back the read() stream with *data*."""
+        self.filename = filename
+        self._buffer = data
+        self._pos = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        """Return up to *size* bytes from the buffered upload."""
+        if size < 0:
+            chunk = self._buffer[self._pos :]
+            self._pos = len(self._buffer)
+            return chunk
+        chunk = self._buffer[self._pos : self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+
+def _ingest_route(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> Any:
+    """Build the app with a fake FastAPI and return its ``/ingest`` route."""
+    _install_fake_fastapi(monkeypatch)
+    app = create_app(**kwargs)
+    return app._routes["POST /ingest"]
+
+
+def test_ingest_rejects_unsupported_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    route = _ingest_route(monkeypatch)
+    upload = _FakeUpload("malware.exe", b"data")
+    response = asyncio.run(route(file=upload))
+    assert response.status_code == 400
+    assert response.content["error"] == "unsupported file extension"
+    assert "allowed_extensions" in response.content
+
+
+def test_ingest_rejects_oversize_upload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    route = _ingest_route(monkeypatch, max_upload_bytes=4)
+    upload = _FakeUpload("statement.csv", b"way too many bytes")
+    response = asyncio.run(route(file=upload))
+    assert response.status_code == 413
+    assert response.content["error"] == "upload exceeds maximum size"
+    assert response.content["max_upload_bytes"] == 4
+
+
+def test_ingest_success_returns_serialized_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    class _MockResult:
+        source_method = "deterministic"
+        source_format = "csv"
+        transactions: ClassVar[list[Any]] = []
+        verification = None
+        warnings = ()
+
+    import bankstatementparser.hybrid as hybrid_pkg
+
+    monkeypatch.setattr(
+        hybrid_pkg, "smart_ingest", lambda _path: _MockResult()
+    )
+
+    route = _ingest_route(monkeypatch)
+    upload = _FakeUpload("statement.csv", b"date,amount\n2026-01-01,1.00\n")
+    response = asyncio.run(route(file=upload))
+    assert response.status_code == 200
+    assert response.content["source_method"] == "deterministic"
+    assert response.content["transaction_count"] == 0
+
+
+def test_ingest_failure_returns_correlation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    import bankstatementparser.hybrid as hybrid_pkg
+
+    def _boom(_path: str) -> Any:
+        raise RuntimeError("secret /tmp/path leaked")
+
+    monkeypatch.setattr(hybrid_pkg, "smart_ingest", _boom)
+
+    route = _ingest_route(monkeypatch)
+    upload = _FakeUpload("statement.csv", b"date,amount\n")
+    response = asyncio.run(route(file=upload))
+    assert response.status_code == 422
+    assert response.content["error"] == "ingest failed"
+    # The raw error message must NOT leak to the client.
+    assert "secret" not in str(response.content)
+    assert len(response.content["correlation_id"]) == 32

--- a/tests/test_enrichment_categorizer.py
+++ b/tests/test_enrichment_categorizer.py
@@ -23,6 +23,7 @@ from bankstatementparser.enrichment import (
     EnrichedTransaction,
 )
 from bankstatementparser.enrichment.categorizer import (
+    CategorizerError,
     _build_messages,
     _format_row,
 )
@@ -548,3 +549,30 @@ def test_build_messages_includes_schema() -> None:
     assert "Food and Drink" in messages[0]["content"]
     assert messages[1]["role"] == "user"
     assert "Coffee" in messages[1]["content"]
+
+
+def test_resolve_completion_defaults_to_litellm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no injected callable, the LiteLLM completion is returned."""
+    import sys
+    import types
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = lambda **_: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    cat = Categorizer()
+    assert cat._resolve_completion() is fake_litellm.completion
+
+
+def test_resolve_completion_missing_litellm_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing LiteLLM dependency raises a clear CategorizerError."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    cat = Categorizer()
+    with pytest.raises(CategorizerError, match="litellm is required"):
+        cat._resolve_completion()

--- a/tests/test_hybrid_ollama_direct.py
+++ b/tests/test_hybrid_ollama_direct.py
@@ -315,6 +315,18 @@ def test_skips_unknown_content_blocks(
 # ---------------------------------------------------------------------------
 
 
+def test_raises_when_httpx_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing httpx dependency raises a clear OllamaDirectError."""
+    monkeypatch.setitem(sys.modules, "httpx", None)
+    with pytest.raises(OllamaDirectError, match="httpx is required"):
+        ollama_direct_completion(
+            model="ollama/llava",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
 def test_raises_when_model_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -434,3 +446,48 @@ def test_extractors_skip_direct_bridge_for_non_ollama(
     ext = LLMExtractor(model="anthropic/claude-3-haiku")
     fn = ext._resolve_completion()
     assert fn is fake_litellm.completion
+
+
+def test_vision_extractor_defaults_to_litellm_for_non_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-Ollama vision model resolves to the LiteLLM completion."""
+    from bankstatementparser.hybrid.vision import VisionExtractor
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_litellm.completion = lambda **_: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    ext = VisionExtractor(model="anthropic/claude-3-haiku")
+    fn = ext._resolve_completion()
+    assert fn is fake_litellm.completion
+
+
+def test_vision_extractor_missing_litellm_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing LiteLLM dependency raises a clear VisionExtractorError."""
+    from bankstatementparser.hybrid.vision import (
+        VisionExtractor,
+        VisionExtractorError,
+    )
+
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    ext = VisionExtractor(model="anthropic/claude-3-haiku")
+    with pytest.raises(VisionExtractorError, match="litellm is required"):
+        ext._resolve_completion()
+
+
+def test_llm_extractor_missing_litellm_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing LiteLLM dependency raises a clear LLMExtractorError."""
+    from bankstatementparser.hybrid.llm_extractor import (
+        LLMExtractor,
+        LLMExtractorError,
+    )
+
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    ext = LLMExtractor(model="anthropic/claude-3-haiku")
+    with pytest.raises(LLMExtractorError, match="litellm is required"):
+        ext._resolve_completion()

--- a/tests/test_hybrid_orchestrator.py
+++ b/tests/test_hybrid_orchestrator.py
@@ -341,6 +341,21 @@ def test_coerce_transactions_handles_none() -> None:
     assert orchestrator._coerce_transactions(None, source="csv") == []
 
 
+def test_coerce_transactions_to_dict_typeerror_falls_back() -> None:
+    """Objects whose ``to_dict`` raises ``TypeError`` yield no records."""
+
+    class _BadToDict:
+        def to_dict(self, *_args: object) -> object:
+            raise TypeError("not a DataFrame")
+
+    assert orchestrator._coerce_transactions(_BadToDict(), source="csv") == []
+
+
+def test_coerce_transactions_unsupported_type_yields_empty() -> None:
+    """Inputs that are neither dict/list nor DataFrame-like yield no rows."""
+    assert orchestrator._coerce_transactions(42, source="csv") == []
+
+
 def test_smart_ingest_routes_scanned_pdf_to_vision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_hybrid_pdf_text.py
+++ b/tests/test_hybrid_pdf_text.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -107,3 +108,90 @@ def test_extract_text_pages_returns_per_page_list(
 def test_extract_text_pages_missing_file_raises(tmp_path: Path) -> None:
     with pytest.raises(PDFExtractionError, match="not found"):
         pdf_text.extract_text_pages(tmp_path / "nope.pdf")
+
+
+def test_extract_text_unknown_engine_raises(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+    with pytest.raises(PDFExtractionError, match="Unknown PDF engine"):
+        pdf_text.extract_text_pages(pdf_path, engine="bogus")  # type: ignore[arg-type]
+
+
+def test_extract_text_pypdf_missing_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+    monkeypatch.setitem(sys.modules, "pypdf", None)
+    with pytest.raises(PDFExtractionError, match="pypdf is required"):
+        extract_text(pdf_path)
+
+
+def test_extract_text_pypdf_read_failure_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+
+    class _Reader:
+        def __init__(self, _path: str) -> None:
+            raise ValueError("corrupt PDF")
+
+    fake = types.ModuleType("pypdf")
+    fake.PdfReader = _Reader  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypdf", fake)
+    with pytest.raises(PDFExtractionError, match="Failed to read PDF"):
+        extract_text(pdf_path)
+
+
+def test_extract_text_pdfplumber_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+
+    class _Page:
+        def extract_text(self) -> str:
+            return "plumber   text"
+
+    class _PDF:
+        pages: ClassVar[list[_Page]] = [_Page()]
+
+        def __enter__(self) -> _PDF:
+            return self
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    fake = types.ModuleType("pdfplumber")
+    fake.open = lambda _path: _PDF()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pdfplumber", fake)
+
+    pages = pdf_text.extract_text_pages(pdf_path, engine="pdfplumber")
+    assert pages == ["plumber text"]
+
+
+def test_extract_text_pdfplumber_missing_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+    monkeypatch.setitem(sys.modules, "pdfplumber", None)
+    with pytest.raises(PDFExtractionError, match="pdfplumber is required"):
+        pdf_text.extract_text_pages(pdf_path, engine="pdfplumber")
+
+
+def test_extract_text_pdfplumber_read_failure_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf_path = tmp_path / "demo.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 stub")
+
+    def _boom(_path: str) -> object:
+        raise ValueError("corrupt PDF")
+
+    fake = types.ModuleType("pdfplumber")
+    fake.open = _boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pdfplumber", fake)
+    with pytest.raises(PDFExtractionError, match="Failed to read PDF"):
+        pdf_text.extract_text_pages(pdf_path, engine="pdfplumber")

--- a/tests/test_hybrid_vision.py
+++ b/tests/test_hybrid_vision.py
@@ -604,3 +604,29 @@ def test_build_strip_messages_header_vs_body_prompt() -> None:
     assert body[1]["content"][1]["image_url"]["url"].startswith(
         "data:image/png;base64,"
     )
+
+
+def test_render_pages_missing_pypdfium2_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_render_pages`` raises a clear error when pypdfium2 is absent."""
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+    monkeypatch.setitem(sys.modules, "pypdfium2", None)
+    extractor = VisionExtractor(completion_fn=lambda **_: None)
+    with pytest.raises(VisionExtractorError, match="pypdfium2 is required"):
+        extractor._render_pages(pdf_path)
+
+
+def test_render_strips_missing_pypdfium2_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_render_strips`` raises a clear error when pypdfium2 is absent."""
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"%PDF stub")
+    monkeypatch.setitem(sys.modules, "pypdfium2", None)
+    extractor = VisionExtractor(
+        completion_fn=lambda **_: None, strip_rows=True
+    )
+    with pytest.raises(VisionExtractorError, match="pypdfium2 is required"):
+        extractor._render_strips(pdf_path)

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -299,6 +299,55 @@ class TestParallelParsing(unittest.TestCase):
         results = parse_files_parallel([])
         self.assertEqual(results, [])
 
+    def test_parallel_worker_crash_is_captured(self) -> None:
+        """A future that raises (e.g. a dead worker) becomes a FAILED result."""
+        from unittest import mock
+
+        from bankstatementparser import parallel
+
+        class _DeadFuture:
+            """Stand-in future whose result() raises like a crashed worker."""
+
+            def result(self) -> object:
+                """Raise as if the worker process had died."""
+                raise RuntimeError("worker process died")
+
+        class _FakeExecutor:
+            """Context-manager executor that hands back dead futures."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                """Accept and ignore any executor configuration."""
+
+            def __enter__(self) -> _FakeExecutor:
+                """Enter the executor context."""
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                """Exit the executor context without suppressing errors."""
+                return False
+
+            def submit(
+                self, _fn: object, path: str, *_args: object
+            ) -> _DeadFuture:
+                """Return a dead future for the given path."""
+                self._path = path
+                return _DeadFuture()
+
+        with (
+            mock.patch.object(parallel, "ProcessPoolExecutor", _FakeExecutor),
+            mock.patch.object(
+                parallel, "as_completed", lambda mapping: list(mapping)
+            ),
+        ):
+            results = parallel.parse_files_parallel(
+                ["/a.xml", "/b.xml"], format_name="camt"
+            )
+
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertEqual(r.status, "FAILED")
+            self.assertIn("RuntimeError", r.error)
+
     def test_parallel_preserves_order(self) -> None:
         """Results maintain input order."""
         from bankstatementparser.parallel import (

--- a/tests/test_regression_examples.py
+++ b/tests/test_regression_examples.py
@@ -88,6 +88,48 @@ def _bash() -> str:
 
 
 # ----------------------------------------------------------------------
+# Completeness guard — no example may be silently omitted
+# ----------------------------------------------------------------------
+
+# ``common.py`` is a shared import-only helper (CLI/path utilities used
+# by the other scripts); it is not a standalone, runnable demo and so is
+# deliberately excluded from end-to-end execution.
+_NON_RUNNABLE_EXAMPLES = frozenset({"common.py"})
+
+
+def _discovered_example_scripts() -> set[str]:
+    """Return every runnable example script path, relative to examples/."""
+    found: set[str] = set()
+    for pattern in ("*.py", "*.sh", "*.ps1"):
+        for path in EXAMPLES_DIR.rglob(pattern):
+            if "__pycache__" in str(path):
+                continue
+            rel = path.relative_to(EXAMPLES_DIR).as_posix()
+            if path.name in _NON_RUNNABLE_EXAMPLES:
+                continue
+            found.add(rel)
+    return found
+
+
+def test_every_example_script_is_exercised() -> None:
+    """Each runnable example on disk is referenced by this suite.
+
+    Guards against an example being added to ``examples/`` without a
+    matching regression test — the discovered set on disk must equal
+    the set this module exercises.
+    """
+    suite_source = Path(__file__).read_text(encoding="utf-8")
+    discovered = _discovered_example_scripts()
+    missing = sorted(
+        rel for rel in discovered if Path(rel).name not in suite_source
+    )
+    assert not missing, (
+        "These example scripts exist on disk but are not exercised by "
+        f"tests/test_regression_examples.py: {missing}"
+    )
+
+
+# ----------------------------------------------------------------------
 # Deterministic examples (no optional extras required)
 # ----------------------------------------------------------------------
 
@@ -199,6 +241,13 @@ def test_hybrid_04_golden_rule() -> None:
 def test_hybrid_05_dedupe_recurring() -> None:
     out = _run_example(HYBRID_DIR / "05_dedupe_recurring.py")
     assert "normalize_description() strips noise" in out
+
+
+def test_hybrid_07_scan_and_ingest() -> None:
+    out = _run_example(HYBRID_DIR / "07_scan_and_ingest.py")
+    assert "Files ingested:" in out
+    assert "Unique transactions:" in out
+    assert "Continuity status:" in out
 
 
 _PDF_GEN_DEPS = ("reportlab", "pypdfium2", "PIL")


### PR DESCRIPTION
Adversarial full-quality audit. Honest findings:

- **Docstrings were 70.1%, not 100%** — the repo had **no `[tool.interrogate]` config at all**. Added the gate (fail-under=100) and documented all **115** missing symbols.
- **`# pragma: no cover` 29 → 2** — several hid genuinely testable code, most egregiously the **entire `/ingest` REST endpoint** (with a false comment claiming smoke tests that didn't exist). Added real tests for the API, optional-dep ImportError guards, vision/llm/categorizer/ollama paths, parallel worker-crash, and CLI branches; deleted truly-dead returns.
- **API/examples gaps**: `verify_transactions`, `verify_continuity` (in neither README nor examples) and `scan_and_ingest` (README only) now documented + exercised (extended `04_golden_rule.py`, new `07_scan_and_ingest.py`). `UNVERIFIABLE` confirmed in README + example.
- Stale counts fixed: **844 tests**, **23 scripts**.

Gates: 861 passed, **genuine 100%** line+branch, interrogate **100%** whole-repo, ruff + mypy clean. Version held at 0.0.9 ([Unreleased]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)