### PR TITLE
chore(release): v0.0.10

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported | Notes |
 |---|---|---|
-| 0.0.9 (current) | Yes | Requires Python ≥ 3.10 (LLM extras: ≤ 3.13) |
+| 0.0.10 (current) | Yes | Requires Python ≥ 3.10 (LLM extras: ≤ 3.13) |
+| 0.0.9 | Yes | Requires Python ≥ 3.10 (LLM extras: ≤ 3.13) |
 | 0.0.8 | Yes | Requires Python ≥ 3.10 |
 | 0.0.7 | Yes | Requires Python ≥ 3.10 |
 | 0.0.6 | Yes | Requires Python ≥ 3.10 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.0.10] — 2026-06-25
+
 ### Added
 
 - New `examples/hybrid/07_scan_and_ingest.py` example demonstrating

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/bankstatementparser/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/bankstatementparser/quality-gates.yml?style=for-the-badge&logo=github" alt="Build" /></a>
-  <a href="https://pypi.org/project/bankstatementparser/"><img src="https://img.shields.io/pypi/pyversions/bankstatementparser.svg?style=for-the-badge&v=0.0.9" alt="PyPI" /></a>
+  <a href="https://pypi.org/project/bankstatementparser/"><img src="https://img.shields.io/pypi/pyversions/bankstatementparser.svg?style=for-the-badge&v=0.0.10" alt="PyPI" /></a>
   <a href="https://pypi.org/project/bankstatementparser/"><img src="https://img.shields.io/pypi/dm/bankstatementparser.svg?style=for-the-badge" alt="PyPI Downloads" /></a>
   <a href="https://codecov.io/github/sebastienrousseau/bankstatementparser?branch=main"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/bankstatementparser?style=for-the-badge" alt="Codecov" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/sebastienrousseau/bankstatementparser?style=for-the-badge" alt="License" /></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bankstatementparser"
-version = "0.0.9"
+version = "0.0.10"
 description = "BankStatementParser is your essential tool for easy bank statement management. Designed with finance and treasury experts in mind, it offers a simple way to handle CAMT (ISO 20022) formats and more. Get quick, accurate insights from your financial data and spend less time on processing. It's the smart, hassle-free way to stay on top of your transactions."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache Software License"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@
 
 [metadata]
 name = bankstatementparser
-version = 0.0.9
+version = 0.0.10
 description = BankStatementParser is your essential tool for easy bank statement management. Designed with financial efficiency in mind.
 keywords =  banking, finance, parsing, CAMT, ISO20022, treasury, SEPA, analysis, transactions, reporting
 author = Sebastian Rousseau


### PR DESCRIPTION
Prepares the **0.0.10** release: folds the `[Unreleased]` changes into a dated `[0.0.10]` CHANGELOG entry and bumps the version across `pyproject.toml`, `setup.cfg`, the README badge, and `.github/SECURITY.md`.

### Release contents
- **`VerificationStatus.UNVERIFIABLE`** + clearer deterministic-detection warning (#99)
- **Documentation audit**: added the `[tool.interrogate]` 100% gate + 115 docstrings (docstrings were silently at ~70% — no gate existed)
- **Coverage-integrity audit**: `# pragma: no cover` **29 → 2**, including the previously-untested `/ingest` REST endpoint; `verify_transactions`/`verify_continuity`/`scan_and_ingest` now documented + exampled (#100)

### Gates
861 passed, **100% line+branch coverage**, interrogate **100%** repo-wide, ruff + mypy strict clean, doc-accuracy version consistency green (pyproject = setup.cfg = README badge = CHANGELOG `[0.0.10]` = SECURITY.md).

> **Note:** the core publishes via `make release` (GPG-signed tag + `poetry publish`), which needs the maintainer's signing key + PyPI token — so the actual PyPI upload is a manual step for the maintainer after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)