### PR TITLE
ci: token-free PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+# Token-free PyPI publishing via OIDC trusted publishing. Trigger
+# manually for a given tag, or automatically when a GitHub release is
+# published. Requires a PyPI "trusted publisher" configured for the
+# bankstatementparser project pointing at this workflow + the "pypi"
+# environment.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and publish (e.g. v0.0.10)"
+        required: true
+        default: "v0.0.10"
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # OIDC for PyPI trusted publishing
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bankstatementparser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify package version matches the tag
+        run: |
+          REF="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          TAG="${REF#v}"
+          PKG=$(grep -m1 '^version' pyproject.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $REF does not match package version $PKG" >&2
+            exit 1
+          fi
+
+      - name: Twine metadata check
+        run: |
+          python -m pip install twine
+          twine check dist/*
+
+      - name: Publish via OIDC trusted publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
Adds OIDC **trusted publishing** so the core can be published to PyPI from CI with no long-lived token — same mechanism the 5 companion packages use.

- Triggers: `workflow_dispatch` (with a `tag` input) or `release: published`.
- SHA-pinned actions (matches this repo's security posture); `id-token: write` for OIDC; `environment: pypi`.
- Builds sdist+wheel, verifies the version matches the tag, `twine check`, then publishes.

Enables publishing **v0.0.10** (already tagged + GitHub-released) once the PyPI trusted publisher is configured. Does not replace `make release`; it's an additional token-free path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)