### PR TITLE
ci: land the CodeQL 4.37.6 bumps together, and group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3
 
       - name: Analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3
         with:
           languages: ${{ matrix.language }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
         uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38
 
       - name: Analyze
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3
 
   secret-scanning:
     name: Secret Scanning


### PR DESCRIPTION
Consolidates #173 , and stops the split recurring.

## Why they had to land together

CodeQL requires every `github/codeql-action/*` step in a run to be the **same version**. Dependabot opens one pull request per sub-action, so each bumped one and left its partner behind:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```

`init` and `analyze` sit in the same workflow file. Each of those pull requests was therefore individually unmergeable, and would have stayed red however many times it was re-run.

Every `codeql-action` reference on this branch now resolves to one pinned SHA (`5595ccaf` — v4.37.6). Dependabot authorship is preserved via `cherry-pick -x`.
177 178
## The permanent fix

The github-actions ecosystem had no `groups:` key, which is what let the bumps split. Adding the wildcard group already used by `camt053` and the other grouped repositories:

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

The pattern held exactly across the fleet: every repository **with** a group has green CodeQL bumps; every repository **without** one has them split and failing. A configuration gap, not a bad release.